### PR TITLE
Fix for the mine operation initialization error

### DIFF
--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/AltchainPopMiner.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/AltchainPopMiner.kt
@@ -191,14 +191,14 @@ class AltchainPopMiner(
         workflowAuthority.submit(state)
         operations[state.id] = state
 
-        return if (state.status != OperationStatus.UNKNOWN) {
+        if (state.status != OperationStatus.UNKNOWN) {
             logger.info { "Created operation [${state.id}] on chain ${state.chainId}" }
 
-            success {
+            return success {
                 addMessage("v000", state.id, "")
             }
         } else {
-            failure {
+            return failure {
                 addMessage("v500", "Unable to mine", "Operation initialization error")
             }
         }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/AltchainPopMiner.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/AltchainPopMiner.kt
@@ -191,14 +191,14 @@ class AltchainPopMiner(
         workflowAuthority.submit(state)
         operations[state.id] = state
 
-        if (state.status != OperationStatus.UNKNOWN) {
+        return if (state.status != OperationStatus.UNKNOWN) {
             logger.info { "Created operation [${state.id}] on chain ${state.chainId}" }
 
-            return success {
+            success {
                 addMessage("v000", state.id, "")
             }
         } else {
-            return failure {
+            failure {
                 addMessage("v500", "Unable to mine", "Operation initialization error")
             }
         }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/WorkflowAuthority.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/WorkflowAuthority.kt
@@ -35,12 +35,13 @@ class WorkflowAuthority(
             onWorkflowStateChanged(it, operation, chain)
         }
 
+        // Begin running
+        operation.begin()
+
         Threading.TASK_POOL.submit {
-            // Begin running
-            operation.begin()
             // Initial task
             executeTask(GetPublicationDataTask(nodeCoreLiteKit, chain), operation)
-        }.get(5, TimeUnit.SECONDS)
+        }
     }
 
     fun restore(operation: MiningOperation) {

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/WorkflowAuthority.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/WorkflowAuthority.kt
@@ -16,6 +16,7 @@ import org.veriblock.miners.pop.core.error
 import org.veriblock.miners.pop.service.PluginService
 import org.veriblock.sdk.alt.SecurityInheritingChain
 import org.veriblock.core.utilities.createLogger
+import java.util.concurrent.TimeUnit
 
 private val logger = createLogger {}
 
@@ -39,7 +40,7 @@ class WorkflowAuthority(
             operation.begin()
             // Initial task
             executeTask(GetPublicationDataTask(nodeCoreLiteKit, chain), operation)
-        }
+        }.get(5, TimeUnit.SECONDS)
     }
 
     fun restore(operation: MiningOperation) {


### PR DESCRIPTION
Basically the function operation.begin() is called after the operation status check (because of Threading...), causing the fail() message, this solves the issue as it will wait for the task completion before the status check, although this might not be the best solution (is operation.begin() intended to be inside the Threading.submit? @PCasafont)