### PR TITLE
Configuration Rework

### DIFF
--- a/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/NxtFamilyChain.kt
+++ b/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/NxtFamilyChain.kt
@@ -13,7 +13,6 @@ import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.fuel.httpPost
 import com.google.gson.Gson
-import org.veriblock.core.utilities.Configuration
 import org.veriblock.core.utilities.createLogger
 import org.veriblock.core.utilities.extensions.asHexBytes
 import org.veriblock.core.utilities.extensions.toHex
@@ -78,12 +77,11 @@ private data class NxtTransactionData(
 
 @FamilyPluginSpec(name = "NxtFamily", key = "nxt")
 class NxtFamilyChain(
+    override val config: NxtConfig,
     val id: Long,
     val key: String,
     val name: String
 ) : SecurityInheritingChain {
-
-    override val config = Configuration.extract("securityInheriting.$key") ?: NxtConfig()
 
     init {
         config.checkValidity()

--- a/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/PluginsModule.kt
+++ b/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/PluginsModule.kt
@@ -10,23 +10,43 @@ package org.veriblock.alt.plugins
 
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.veriblock.core.utilities.Configuration
 import org.veriblock.sdk.alt.SecurityInheritingChain
 
 typealias NormalPluginsContainer = Map<String, SecurityInheritingChain>
 typealias FamilyPluginsContainer = Map<String, (Long, String, String) -> SecurityInheritingChain>
 
 val pluginsModule = module {
+
     // Normal plugins
     single<NormalPluginsContainer>(named("normal-plugins")) {
+        val configuration: Configuration = get()
         mapOf(
-            "test" to TestChain()
+            "test" to TestChain(configuration.extract("securityInheriting.test") ?: TestConfig())
         )
     }
     // Family plugins
     single<FamilyPluginsContainer>(named("family-plugins")) {
+        val configuration: Configuration = get()
         mapOf(
-            "btc" to { id, key, name -> BitcoinFamilyChain(id, key, name) },
-            "nxt" to { id, key, name -> NxtFamilyChain(id, key, name) }
+            "btc" to { id, key, name ->
+                BitcoinFamilyChain(
+                    configuration.extract("securityInheriting.btc")
+                        ?: error("Please configure the securityInheriting.$key section"),
+                    id,
+                    key,
+                    name
+                )
+            },
+            "nxt" to { id, key, name ->
+                NxtFamilyChain(
+                    configuration.extract("securityInheriting.$key")
+                        ?: NxtConfig(),
+                    id,
+                    key,
+                    name
+                )
+            }
         )
     }
 }

--- a/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/TestChain.kt
+++ b/altchain-plugins/src/main/kotlin/org/veriblock/alt/plugins/TestChain.kt
@@ -9,7 +9,6 @@
 package org.veriblock.alt.plugins
 
 import com.github.kittinunf.fuel.httpPost
-import org.veriblock.core.utilities.Configuration
 import org.veriblock.core.utilities.createLogger
 import org.veriblock.core.utilities.extensions.asHexBytes
 import org.veriblock.core.utilities.extensions.toHex
@@ -56,11 +55,11 @@ private class BtcBlockData(
 )
 
 @PluginSpec(name = "Test", key = "test")
-class TestChain : SecurityInheritingChain {
+class TestChain(
+    override val config: TestConfig
+) : SecurityInheritingChain {
 
-    override val config = Configuration.extract("securityInheriting.test") ?: TestConfig()
-
-    val operations = HashMap<String, String>()
+    private val operations = HashMap<String, String>()
 
     init {
         config.checkValidity()

--- a/altchain-plugins/src/test/kotlin/org/veriblock/alt/plugins/TestChainTest.kt
+++ b/altchain-plugins/src/test/kotlin/org/veriblock/alt/plugins/TestChainTest.kt
@@ -16,17 +16,19 @@ import org.junit.Test
  */
 class TestChainTest {
 
+    private val chain = TestChain(TestConfig())
+
     @Test
     @Ignore
     fun getBestBlockHeight() {
-        val data = TestChain().getBestBlockHeight()
+        val data = chain.getBestBlockHeight()
         println(data)
     }
 
     @Test
     @Ignore
     fun getPublicationData() {
-        val data = TestChain().getPublicationData(null)
+        val data = chain.getPublicationData(null)
         println(data)
     }
 }

--- a/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/NodeCoreLiteKit.kt
+++ b/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/NodeCoreLiteKit.kt
@@ -105,13 +105,13 @@ class NodeCoreLiteKit(
         val file = File(context.directory, context.filePrefix + TM_FILE_EXTENSION)
         return if (file.exists()) {
             try {
-                file.loadTransactionMonitor()
+                file.loadTransactionMonitor(context)
             } catch (e: Exception) {
                 throw IOException("Unable to load the transaction monitoring data", e)
             }
         } else {
             val address = Address(addressManager.defaultAddress.hash)
-            TransactionMonitor(address)
+            TransactionMonitor(context, address)
         }
     }
 

--- a/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/core/Context.kt
+++ b/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/core/Context.kt
@@ -8,16 +8,18 @@
 
 package org.veriblock.lite.core
 
-import org.veriblock.lite.params.NetworkParameters
 import org.veriblock.core.utilities.Configuration
+import org.veriblock.lite.params.NetworkParameters
 import java.io.File
 
-object Context {
+class Context(
+    configuration: Configuration,
+    val networkParameters: NetworkParameters
+) {
     val dataDir = System.getenv("DATA_DIR")
-        ?: Configuration.extract("dataDir")
+        ?: configuration.extract("dataDir")
         ?: "./"
 
-    val networkParameters = NetworkParameters
     val directory: File = File(dataDir)
     val filePrefix: String = "vbk-${networkParameters.network}"
 

--- a/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/params/NetworkParameters.kt
+++ b/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/params/NetworkParameters.kt
@@ -8,7 +8,6 @@
 
 package org.veriblock.lite.params
 
-import org.veriblock.core.utilities.Configuration
 import java.math.BigInteger
 
 class NetworkConfig(
@@ -20,12 +19,11 @@ class NetworkConfig(
     val adminPassword: String? = null
 )
 
-private val config: NetworkConfig = Configuration.extract("nodecore")
-    ?: NetworkConfig()
-
 const val LOCALHOST = "127.0.0.1"
 
-object NetworkParameters {
+class NetworkParameters(
+    config: NetworkConfig
+) {
     val network: String
     val adminHost: String
     val adminPort: Int

--- a/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/transactionmonitor/TransactionMonitor.kt
+++ b/altchain-pop-miner/core/src/main/kotlin/org/veriblock/lite/transactionmonitor/TransactionMonitor.kt
@@ -22,7 +22,8 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.*
+import java.util.Collections
+import java.util.HashMap
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -30,6 +31,7 @@ private val logger = createLogger {}
 const val TM_FILE_EXTENSION = ".txmon"
 
 class TransactionMonitor(
+    val context: Context,
     val address: Address,
     transactionsToLoad: List<WalletTransaction> = emptyList()
 ) {
@@ -46,7 +48,7 @@ class TransactionMonitor(
         Collections.unmodifiableCollection(transactions.values)
 
     private fun save() {
-        val diskWallet = File(Context.directory, Context.filePrefix + TM_FILE_EXTENSION)
+        val diskWallet = File(context.directory, context.filePrefix + TM_FILE_EXTENSION)
 
         lock.withLock {
             try {
@@ -217,9 +219,9 @@ class TransactionMonitor(
     }
 }
 
-fun File.loadTransactionMonitor(): TransactionMonitor = try {
+fun File.loadTransactionMonitor(context: Context): TransactionMonitor = try {
     FileInputStream(this).use { stream ->
-        stream.readTransactionMonitor()
+        stream.readTransactionMonitor(context)
     }
 } catch (e: IOException) {
     throw IllegalStateException("Unable to read VBK wallet from disk")

--- a/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/core/RandomObjectGeneration.kt
+++ b/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/core/RandomObjectGeneration.kt
@@ -69,6 +69,7 @@ fun randomPublicationData() = PublicationData(
 )
 
 fun randomWalletTransaction(
+    context: Context,
     type: Byte = 0x01,
     sourceAddress: Address = randomAddress(),
     sourceAmount: Coin = randomCoin(),
@@ -77,7 +78,7 @@ fun randomWalletTransaction(
     publicationData: PublicationData = randomPublicationData(),
     signature: ByteArray = ByteArray(10),
     publicKey: ByteArray = ByteArray(8),
-    networkByte: Byte? = Context.networkParameters.transactionPrefix,
+    networkByte: Byte? = context.networkParameters.transactionPrefix,
     transactionMeta: TransactionMeta = randomTransactionMeta(),
     merklePath: VeriBlockMerklePath = randomVeriBlockMerklePath()
 ): WalletTransaction {
@@ -127,9 +128,10 @@ fun randomSha256Hash(): Sha256Hash {
 }
 
 fun randomTransactionMonitor(
+    context: Context,
     address: Address = randomAddress(),
-    walletTransactions: List<WalletTransaction> = (0..randomInt(20)).map { randomWalletTransaction() }
-) = TransactionMonitor(address, walletTransactions)
+    walletTransactions: List<WalletTransaction> = (0..randomInt(20)).map { randomWalletTransaction(context) }
+) = TransactionMonitor(context, address, walletTransactions)
 
 fun randomVeriBlockMerklePath(
     treeIndex: Int = randomInt(1, 65535),
@@ -153,6 +155,7 @@ fun randomMerklePath(
 }
 
 fun randomVeriBlockTransaction(
+    context: Context,
     type: Byte = 0x01,
     sourceAddress: Address = randomAddress(),
     sourceAmount: Coin = randomCoin(),
@@ -161,7 +164,7 @@ fun randomVeriBlockTransaction(
     publicationData: PublicationData = randomPublicationData(),
     signature: ByteArray = ByteArray(10),
     publicKey: ByteArray = ByteArray(8),
-    networkByte: Byte? = Context.networkParameters.transactionPrefix
+    networkByte: Byte? = context.networkParameters.transactionPrefix
 ): VeriBlockTransaction {
     return VeriBlockTransaction(
         type,
@@ -177,6 +180,7 @@ fun randomVeriBlockTransaction(
 }
 
 fun randomFullBlock(
+    context: Context,
     height: Int = randomInt(0, Int.MAX_VALUE),
     version: Short = randomInt(0, Short.MAX_VALUE.toInt()).toShort(),
     previousBlock: VBlakeHash = randomVBlakeHash(),
@@ -186,8 +190,8 @@ fun randomFullBlock(
     timestamp: Int = randomInt(0, Int.MAX_VALUE),
     difficulty: Int = randomInt(0, Int.MAX_VALUE),
     nonce: Int = randomInt(0, Int.MAX_VALUE),
-    normalTransactions: List<VeriBlockTransaction> = (1..10).map { randomVeriBlockTransaction() },
-    poPTransactions: List<VeriBlockPoPTransaction> = (1..10).map { randomVeriBlockPoPTransaction() },
+    normalTransactions: List<VeriBlockTransaction> = (1..10).map { randomVeriBlockTransaction(context) },
+    poPTransactions: List<VeriBlockPoPTransaction> = (1..10).map { randomVeriBlockPoPTransaction(context) },
     metaPackage: BlockMetaPackage = randomBlockMetaPackage()
 ): FullBlock {
     return FullBlock(
@@ -213,6 +217,7 @@ fun randomBlockMetaPackage(
 }
 
 fun randomVeriBlockPoPTransaction(
+    context: Context,
     address: Address = randomAddress(),
     publishedBlock: VeriBlockBlock = randomVeriBlockBlock(),
     bitcoinTransaction: BitcoinTransaction = randomBitcoinTransaction(),
@@ -221,7 +226,7 @@ fun randomVeriBlockPoPTransaction(
     blockOfProofContext: List<BitcoinBlock> = (1..10).map { randomBitcoinBlock() },
     signature: ByteArray = ByteArray(10),
     publicKey: ByteArray = ByteArray(8),
-    networkByte: Byte? = Context.networkParameters.transactionPrefix
+    networkByte: Byte? = context.networkParameters.transactionPrefix
 ): VeriBlockPoPTransaction {
     return VeriBlockPoPTransaction(
         address,

--- a/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/transactionmonitor/WalletProtobufSerializerTest.kt
+++ b/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/transactionmonitor/WalletProtobufSerializerTest.kt
@@ -10,23 +10,28 @@ package org.veriblock.lite.core
 
 import io.kotlintest.shouldBe
 import org.junit.Test
+import org.veriblock.core.utilities.Configuration
+import org.veriblock.lite.params.NetworkConfig
+import org.veriblock.lite.params.NetworkParameters
 import org.veriblock.lite.transactionmonitor.readTransactionMonitor
 import org.veriblock.lite.transactionmonitor.writeTransactionMonitor
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
 class WalletProtobufSerializerTest {
+    private val networkParameters = NetworkParameters(NetworkConfig())
+    private val context = Context(Configuration(), networkParameters)
 
     @Test
     fun roundTrip() {
         // Given
-        val wallet = randomTransactionMonitor()
+        val wallet = randomTransactionMonitor(context)
         val outputStream = ByteArrayOutputStream()
         outputStream.writeTransactionMonitor(wallet)
         val inputStream = ByteArrayInputStream(outputStream.toByteArray())
 
         // When
-        val roundTrip = inputStream.readTransactionMonitor()
+        val roundTrip = inputStream.readTransactionMonitor(context)
 
         // Then
         wallet shouldBe roundTrip

--- a/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/transactionmonitor/WalletTransactionTest.kt
+++ b/altchain-pop-miner/core/src/test/kotlin/org/veriblock/lite/transactionmonitor/WalletTransactionTest.kt
@@ -10,6 +10,7 @@ package org.veriblock.lite.transactionmonitor
 
 import io.kotlintest.shouldBe
 import org.junit.Test
+import org.veriblock.core.utilities.Configuration
 import org.veriblock.lite.core.Context
 import org.veriblock.lite.core.TransactionMeta
 import org.veriblock.lite.core.randomAddress
@@ -19,9 +20,13 @@ import org.veriblock.lite.core.randomPublicationData
 import org.veriblock.lite.core.randomTransactionMeta
 import org.veriblock.lite.core.randomVeriBlockMerklePath
 import org.veriblock.lite.core.randomWalletTransaction
+import org.veriblock.lite.params.NetworkConfig
+import org.veriblock.lite.params.NetworkParameters
 import org.veriblock.sdk.models.VeriBlockTransaction
 
 class WalletTransactionTest {
+    private val networkParameters = NetworkParameters(NetworkConfig())
+    private val context = Context(Configuration(), networkParameters)
 
     @Test
     fun transactionDataByData() {
@@ -34,12 +39,12 @@ class WalletTransactionTest {
         val publicationData = randomPublicationData()
         val signature = ByteArray(10)
         val publicKey = ByteArray(8)
-        val networkByte: Byte? = Context.networkParameters.transactionPrefix
+        val networkByte: Byte? = networkParameters.transactionPrefix
         val transactionMeta: TransactionMeta = randomTransactionMeta()
         val merklePath = randomVeriBlockMerklePath()
 
         // When
-        val walletTransaction = randomWalletTransaction(type, sourceAddress, sourceAmount,
+        val walletTransaction = randomWalletTransaction(context, type, sourceAddress, sourceAmount,
             outputs, signatureIndex, publicationData, signature, publicKey, networkByte, transactionMeta, merklePath)
 
         // Then
@@ -67,7 +72,7 @@ class WalletTransactionTest {
         val publicationData = randomPublicationData()
         val signature = ByteArray(10)
         val publicKey = ByteArray(8)
-        val networkByte: Byte? = Context.networkParameters.transactionPrefix
+        val networkByte: Byte? = networkParameters.transactionPrefix
 
         // When
         val veriblockTransaction = VeriBlockTransaction(type, sourceAddress, sourceAmount, outputs,

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/Miner.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/Miner.kt
@@ -12,6 +12,12 @@ import org.veriblock.lite.core.Balance
 import org.veriblock.miners.pop.core.MiningOperation
 import org.veriblock.shell.core.Result
 
+class MinerConfig(
+    val feePerByte: Long = 1_000,
+    val maxFee: Long = 10_000_000,
+    val mock: Boolean = false
+)
+
 interface Miner {
     fun initialize()
 
@@ -28,4 +34,7 @@ interface Miner {
     fun mine(chainId: String, block: Int?): Result
 
     fun shutdown()
+
+    val feePerByte: Long
+    val maxFee: Long
 }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/MockMiner.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/MockMiner.kt
@@ -35,11 +35,13 @@ import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
-import java.util.*
+import java.util.ArrayList
+import java.util.HashMap
 
 private val logger = createLogger {}
 
 class MockMiner(
+    private val config: MinerConfig,
     private val pluginFactory: PluginService
 ) : Miner {
     private val connection = ConnectionSelector.setConnection("mock")
@@ -199,4 +201,10 @@ class MockMiner(
     override fun getAddress(): String = "NO ADDRESS"
 
     override fun getBalance(): Balance? = null
+
+    override val feePerByte: Long
+        get() = config.feePerByte
+
+    override val maxFee: Long
+        get() = config.maxFee
 }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/api/ApiServer.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/api/ApiServer.kt
@@ -22,23 +22,24 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import mu.KotlinLogging
 import org.veriblock.core.utilities.Configuration
+import org.veriblock.core.utilities.createLogger
 import org.veriblock.miners.pop.api.controller.ApiController
 import org.veriblock.miners.pop.api.controller.statusPages
 import java.util.concurrent.TimeUnit
 
 const val API_VERSION = "0.1"
 
-private val logger = KotlinLogging.logger {}
+private val logger = createLogger {}
 
 class ApiServer(
+    configuration: Configuration,
     private val controllers: List<ApiController>
 ) {
     private var running = false
 
-    private val port: Int = Configuration.getInt("miner.api.port") ?: 8080
-    private val host: String = Configuration.getString("miner.api.host") ?: "0.0.0.0"
+    private val port: Int = configuration.getInt("miner.api.port") ?: 8080
+    private val host: String = configuration.getString("miner.api.host") ?: "0.0.0.0"
 
     var server: ApplicationEngine? = null
 

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/api/WebApiModule.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/api/WebApiModule.kt
@@ -3,13 +3,15 @@ package org.veriblock.miners.pop.api
 import org.koin.dsl.module
 import org.veriblock.miners.pop.api.controller.MiningController
 
-@JvmField
 val webApiModule = module {
     single { MiningController(get()) }
 
     single {
-        ApiServer(listOf(
-            get<MiningController>()
-        ))
+        ApiServer(
+            get(),
+            listOf(
+                get<MiningController>()
+            )
+        )
     }
 }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/service/PluginService.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/service/PluginService.kt
@@ -25,13 +25,15 @@ class PluginConfig(
     val name: String? = null
 )
 
-class PluginService : KoinComponent {
+class PluginService(
+    configuration: Configuration
+) : KoinComponent {
     val normalPlugins: NormalPluginsContainer by inject(named("normal-plugins"))
     val familyPlugins: FamilyPluginsContainer by inject(named("family-plugins"))
 
     private var loadedPlugins: Map<String, SecurityInheritingChain> = emptyMap()
 
-    private val configuredPlugins: Map<String, PluginConfig> = Configuration.extract("securityInheriting") ?: emptyMap()
+    private val configuredPlugins: Map<String, PluginConfig> = configuration.extract("securityInheriting") ?: emptyMap()
 
     fun loadPlugins() {
         logger.info { "Loading plugins..." }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/service/ServiceModule.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/service/ServiceModule.kt
@@ -12,5 +12,5 @@ import org.koin.dsl.module
 
 val serviceModule = module {
     single { OperationService(get()) }
-    single { PluginService() }
+    single { PluginService(get()) }
 }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/Shell.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/Shell.kt
@@ -8,6 +8,8 @@
 
 package org.veriblock.miners.pop.shell
 
+import org.veriblock.core.utilities.Configuration
+import org.veriblock.lite.core.Context
 import org.veriblock.miners.pop.Miner
 import org.veriblock.miners.pop.shell.commands.configCommands
 import org.veriblock.miners.pop.shell.commands.miningCommands
@@ -16,10 +18,12 @@ import org.veriblock.miners.pop.shell.commands.walletCommands
 import org.veriblock.shell.CommandFactory
 
 fun CommandFactory.configure(
+    configuration: Configuration,
+    context: Context,
     miner: Miner
 ) {
     standardCommands()
-    configCommands()
+    configCommands(configuration)
     miningCommands(miner)
-    walletCommands(miner)
+    walletCommands(context, miner)
 }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/commands/ConfigCommands.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/commands/ConfigCommands.kt
@@ -15,7 +15,9 @@ import org.veriblock.shell.CommandParameterMappers
 import org.veriblock.shell.command
 import org.veriblock.shell.core.success
 
-fun CommandFactory.configCommands() {
+fun CommandFactory.configCommands(
+    configuration: Configuration
+) {
     command(
         name = "List Config",
         form = "listconfig",
@@ -23,7 +25,7 @@ fun CommandFactory.configCommands() {
     ) {
         printInfo("Configuration Properties:")
 
-        val properties = Configuration.list()
+        val properties = configuration.list()
         for ((prop, value) in properties) {
             printInfo("\t$prop=$value")
         }
@@ -42,7 +44,7 @@ fun CommandFactory.configCommands() {
         val key: String = getParameter("key");
         val value: String = getParameter("value");
 
-        Configuration.setProperty(key, value);
+        configuration.setProperty(key, value);
 
         success()
     }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/commands/WalletCommands.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/shell/commands/WalletCommands.kt
@@ -16,8 +16,9 @@ import org.veriblock.shell.command
 import org.veriblock.shell.core.failure
 import org.veriblock.shell.core.success
 
-fun CommandFactory.walletCommands(miner: Miner) {
-
+fun CommandFactory.walletCommands(
+    context: Context, miner: Miner
+) {
     command(
         name = "Get Loaded Address",
         form = "getaddress",
@@ -39,8 +40,8 @@ fun CommandFactory.walletCommands(miner: Miner) {
                 addMessage("V010", "Unable to retrieve balance", "Connection to NodeCore is not healthy")
             }
         }
-        printInfo("Confirmed balance: ${balance.confirmedBalance.formatCoinAmount()} ${Context.vbkTokenName}")
-        printInfo("Pending balance changes: ${balance.pendingBalanceChanges.formatCoinAmount()} ${Context.vbkTokenName}")
+        printInfo("Confirmed balance: ${balance.confirmedBalance.formatCoinAmount()} ${context.vbkTokenName}")
+        printInfo("Pending balance changes: ${balance.pendingBalanceChanges.formatCoinAmount()} ${context.vbkTokenName}")
 
         success()
     }

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/storage/RepositoriesModule.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/storage/RepositoriesModule.kt
@@ -16,10 +16,10 @@ import org.veriblock.miners.pop.storage.ormlite.OrmLiteKeyValueRepository
 import org.veriblock.miners.pop.storage.ormlite.OrmLitePoPRepository
 import java.sql.SQLException
 
-val sqliteDbFile = Context.directory.resolve("pop.dat")
-
 val repositoryModule = module {
     single<ConnectionSource> {
+        val context: Context = get()
+        val sqliteDbFile = context.directory.resolve("pop.dat")
         val url = "jdbc:sqlite:$sqliteDbFile"
         try {
             JdbcPooledConnectionSource(url)

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/BaseTask.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/BaseTask.kt
@@ -10,6 +10,7 @@ package org.veriblock.miners.pop.tasks
 
 import org.veriblock.core.utilities.createLogger
 import org.veriblock.lite.NodeCoreLiteKit
+import org.veriblock.miners.pop.Miner
 import org.veriblock.miners.pop.core.MiningOperation
 import org.veriblock.miners.pop.core.debug
 import org.veriblock.miners.pop.core.error
@@ -18,6 +19,7 @@ import org.veriblock.sdk.alt.SecurityInheritingChain
 private val logger = createLogger {}
 
 abstract class BaseTask protected constructor(
+    protected val miner: Miner,
     protected val nodeCoreLiteKit: NodeCoreLiteKit,
     protected val securityInheritingChain: SecurityInheritingChain
 ) {

--- a/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/Tasks.kt
+++ b/altchain-pop-miner/miner/src/main/kotlin/org/veriblock/miners/pop/tasks/Tasks.kt
@@ -16,10 +16,10 @@ import org.veriblock.core.utilities.extensions.toHex
 import org.veriblock.lite.NodeCoreLiteKit
 import org.veriblock.lite.core.FullBlock
 import org.veriblock.lite.core.PublicationSubscription
+import org.veriblock.miners.pop.Miner
 import org.veriblock.miners.pop.core.MiningOperation
 import org.veriblock.miners.pop.core.OperationState
 import org.veriblock.miners.pop.core.info
-import org.veriblock.miners.pop.minerConfig
 import org.veriblock.miners.pop.util.VTBDebugUtility
 import org.veriblock.sdk.alt.SecurityInheritingChain
 import org.veriblock.sdk.models.AltPublication
@@ -31,13 +31,14 @@ import org.veriblock.sdk.util.Utils
 private val logger = createLogger {}
 
 class GetPublicationDataTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
-        get() = CreateProofTransactionTask(nodeCoreLiteKit, securityInheritingChain)
+        get() = CreateProofTransactionTask(miner, nodeCoreLiteKit, securityInheritingChain)
 
     override fun executeImpl(operation: MiningOperation) {
         logger.info(operation) { "Getting the publication data..." }
@@ -61,10 +62,11 @@ class GetPublicationDataTask(
 }
 
 class CreateProofTransactionTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
         get() = null // We will wait for the transaction to be confirmed, which will trigger DetermineBlockOfProofTask
@@ -90,8 +92,8 @@ class CreateProofTransactionTask(
             }
             nodeCoreLiteKit.network.submitEndorsement(
                 endorsementData,
-                minerConfig.feePerByte,
-                minerConfig.maxFee
+                miner.feePerByte,
+                miner.maxFee
             )
         } catch (e: Exception) {
             failOperation(operation, "Could not create endorsement VBK transaction")
@@ -105,13 +107,14 @@ class CreateProofTransactionTask(
 }
 
 class DetermineBlockOfProofTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
-        get() = ProveTransactionTask(nodeCoreLiteKit, securityInheritingChain)
+        get() = ProveTransactionTask(miner, nodeCoreLiteKit, securityInheritingChain)
 
     override fun executeImpl(operation: MiningOperation) {
         val state = operation.state
@@ -133,13 +136,14 @@ class DetermineBlockOfProofTask(
 }
 
 class ProveTransactionTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
-        get() = RegisterKeystoneListenersTask(nodeCoreLiteKit, securityInheritingChain)
+        get() = RegisterKeystoneListenersTask(miner, nodeCoreLiteKit, securityInheritingChain)
 
     override fun executeImpl(operation: MiningOperation) {
         val state = operation.state
@@ -165,10 +169,11 @@ class ProveTransactionTask(
 }
 
 class RegisterKeystoneListenersTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
         get() = null // We are going to wait for the next Keystone, which will trigger RegisterVeriBlockPublicationPollingTask
@@ -209,10 +214,11 @@ class RegisterKeystoneListenersTask(
 }
 
 class RegisterVeriBlockPublicationPollingTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
         get() = null // We will be waiting for this operation's veriblock publication, which will trigger the SubmitProofOfProofTask
@@ -247,13 +253,14 @@ class RegisterVeriBlockPublicationPollingTask(
 }
 
 class SubmitProofOfProofTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
-        get() = DeregisterVeriBlockPublicationPollingTask(nodeCoreLiteKit, securityInheritingChain)
+        get() = DeregisterVeriBlockPublicationPollingTask(miner, nodeCoreLiteKit, securityInheritingChain)
 
     override fun executeImpl(operation: MiningOperation) {
         val state = operation.state
@@ -341,10 +348,11 @@ class SubmitProofOfProofTask(
 }
 
 class DeregisterVeriBlockPublicationPollingTask(
+    miner: Miner,
     nodeCoreLiteKit: NodeCoreLiteKit,
     securityInheritingChain: SecurityInheritingChain
 ) : BaseTask(
-    nodeCoreLiteKit, securityInheritingChain
+    miner, nodeCoreLiteKit, securityInheritingChain
 ) {
     override val next: BaseTask?
         get() = null


### PR DESCRIPTION
* The config is no longer a singleton. It can be injected to each component, which allows more flexibility in tests
* Updated all usages of the config singleton in APM to proper component injections
* Converted APM's Context and NetworkParameters objects into injectable components as well
* Added config injection in the Altchain Plugins module (if there's no config injected when the module is loaded, it will crash with a missing bean exception)
* Fixed tests to mock out config and context objects