### PR TITLE
Converted SPV Context into an object instead of global state

### DIFF
--- a/nodecore-cli/src/main/java/nodecore/cli/commands/shell/ConnectionCommands.kt
+++ b/nodecore-cli/src/main/java/nodecore/cli/commands/shell/ConnectionCommands.kt
@@ -4,7 +4,6 @@ import nodecore.cli.annotations.ModeType
 import nodecore.cli.cliCommand
 import nodecore.cli.cliShell
 import nodecore.cli.commands.ShellCommandParameterMappers
-import nodecore.cli.contracts.EndpointTransportType
 import nodecore.cli.contracts.PeerEndpoint
 import nodecore.cli.contracts.ProtocolEndpoint
 import nodecore.cli.contracts.ProtocolEndpointType
@@ -12,9 +11,7 @@ import org.veriblock.shell.CommandFactory
 import org.veriblock.shell.CommandParameter
 import org.veriblock.shell.CommandParameterMappers
 import org.veriblock.shell.core.success
-import veriblock.Context
 import veriblock.conf.NetworkParameters
-import veriblock.model.DownloadStatusResponse
 import veriblock.net.BootstrapPeerDiscovery
 import veriblock.net.LocalhostDiscovery
 import veriblock.net.PeerDiscovery
@@ -70,13 +67,13 @@ fun CommandFactory.connectionCommands() {
         val peer: String? = getOptionalParameter("peer")
 
         // Work with bootstraps peers by default.
-        var peerDiscovery: PeerDiscovery = if (peer != null && peer == "local") LocalhostDiscovery() else BootstrapPeerDiscovery(net)
+        val peerDiscovery: PeerDiscovery = if (peer == "local") LocalhostDiscovery(net) else BootstrapPeerDiscovery(net)
 
         val endpoint = shell.startSPV(net, peerDiscovery)
 
         this.extraData["connect"] = endpoint
         this.extraData["disconnectCallBack"] = Runnable {
-            Context.shutdown()
+            shell.spvContext.shutdown()
         }
 
         success()

--- a/nodecore-spv/src/main/java/veriblock/SpvContext.java
+++ b/nodecore-spv/src/main/java/veriblock/SpvContext.java
@@ -24,6 +24,7 @@ import org.veriblock.sdk.models.BitcoinBlock;
 import org.veriblock.sdk.models.VeriBlockBlock;
 import org.veriblock.sdk.sqlite.ConnectionSelector;
 import org.veriblock.sdk.sqlite.FileManager;
+import veriblock.conf.NetworkParameters;
 import veriblock.listeners.PendingTransactionDownloadedListener;
 import veriblock.model.TransactionPool;
 import veriblock.net.P2PService;
@@ -31,7 +32,6 @@ import veriblock.net.PeerDiscovery;
 import veriblock.net.PeerTable;
 import veriblock.net.impl.P2PServiceImpl;
 import veriblock.net.impl.PeerTableImpl;
-import veriblock.conf.NetworkParameters;
 import veriblock.service.AdminApiService;
 import veriblock.service.PendingTransactionContainer;
 import veriblock.service.impl.AdminApiServiceImpl;
@@ -54,45 +54,45 @@ import java.time.Instant;
  * Initialize and hold beans/classes.
  * Required initialization. Context.init(....)
  */
-public class Context {
-    private static final Logger log = LoggerFactory.getLogger(Context.class);
+public class SpvContext {
+    private static final Logger log = LoggerFactory.getLogger(SpvContext.class);
 
-    private static NetworkParameters networkParameters;
-    private static File directory;
-    private static String filePrefix;
-    private static TransactionPool transactionPool;
+    private NetworkParameters networkParameters;
+    private File directory;
+    private String filePrefix;
+    private TransactionPool transactionPool;
 
-    private static VeriBlockStore veriBlockStore;
-    private static BitcoinStore bitcoinStore;
+    private VeriBlockStore veriBlockStore;
+    private BitcoinStore bitcoinStore;
 
-    private static AuditorChangesStore auditStore;
-    private static Blockchain blockchain;
-    private static Instant startTime = Instant.now();
-    private static AdminApiService adminApiService;
-    private static AdminServiceFacade adminService;
-    private static AdminServerInterceptor adminServerInterceptor;
-    private static PeerTable peerTable;
-    private static P2PService p2PService;
-    private static Server server;
-    private static AddressManager addressManager;
-    private static TransactionService transactionService;
-    private static PendingTransactionContainer pendingTransactionContainer;
-    private static PendingTransactionDownloadedListener pendingTransactionDownloadedListener;
+    private AuditorChangesStore auditStore;
+    private Blockchain blockchain;
+    private Instant startTime = Instant.now();
+    private AdminApiService adminApiService;
+    private AdminServiceFacade adminService;
+    private AdminServerInterceptor adminServerInterceptor;
+    private PeerTable peerTable;
+    private P2PService p2PService;
+    private Server server;
+    private AddressManager addressManager;
+    private TransactionService transactionService;
+    private PendingTransactionContainer pendingTransactionContainer;
+    private PendingTransactionDownloadedListener pendingTransactionDownloadedListener;
 
     public static final String FILE_EXTENSION = ".vbkwallet";
 
     /**
      * Initialise context. This method should be call on the start app.
      *
-     * @param networkParam Config for particular network.
-     * @param baseDir will use as a start point for inner directories. (db, wallet so on.)
-     * @param filePr prefix for wallet name. (for example: vbk-MainNet, vbk-TestNet)
-     * @param peerDiscovery discovery peers.
+     * @param networkParam   Config for particular network.
+     * @param baseDir        will use as a start point for inner directories. (db, wallet so on.)
+     * @param filePr         prefix for wallet name. (for example: vbk-MainNet, vbk-TestNet)
+     * @param peerDiscovery  discovery peers.
      * @param runAdminServer Start Admin RPC service. (It can be not necessary for tests.)
      */
-    public static synchronized void init(NetworkParameters networkParam, File baseDir, String filePr, PeerDiscovery peerDiscovery, boolean runAdminServer) {
+    public synchronized void init(NetworkParameters networkParam, File baseDir, String filePr, PeerDiscovery peerDiscovery, boolean runAdminServer) {
         try {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> Context.shutdown(), "ShutdownHook nodecore-spv"));
+            Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown, "ShutdownHook nodecore-spv"));
 
             networkParameters = networkParam;
             directory = baseDir;
@@ -107,70 +107,66 @@ public class Context {
 
             auditStore = new AuditorChangesStore(ConnectionSelector.setConnectionDefault());
             transactionPool = new TransactionPool();
-            blockchain = new Blockchain(veriBlockStore);
-
-
+            blockchain = new Blockchain(networkParameters, veriBlockStore);
 
             pendingTransactionContainer = new PendingTransactionContainerImpl();
-            p2PService = new P2PServiceImpl(pendingTransactionContainer);
+            p2PService = new P2PServiceImpl(pendingTransactionContainer, networkParameters);
 
             addressManager = new DefaultAddressManager();
-            File walletFile = new File(Context.getDirectory(), Context.getFilePrefix() + FILE_EXTENSION);
+            File walletFile = new File(getDirectory(), getFilePrefix() + FILE_EXTENSION);
             addressManager.load(walletFile);
 
-            peerTable = new PeerTableImpl(p2PService, peerDiscovery);
+            peerTable = new PeerTableImpl(this, p2PService, peerDiscovery);
             transactionService = new TransactionService(addressManager);
-            adminApiService = new AdminApiServiceImpl(peerTable, transactionService, addressManager, new TransactionFactoryImpl(),
-                    pendingTransactionContainer, blockchain);
+            adminApiService =
+                new AdminApiServiceImpl(this, peerTable, transactionService, addressManager, new TransactionFactoryImpl(networkParameters),
+                    pendingTransactionContainer, blockchain
+                );
 
             adminService = new AdminServiceFacade(adminApiService);
             adminServerInterceptor = new AdminServerInterceptor();
 
-            if(runAdminServer) {
+            if (runAdminServer) {
                 peerTable.start();
                 server = createAdminServer();
             }
 
-            pendingTransactionDownloadedListener = new PendingTransactionDownloadedListenerImpl();
+            pendingTransactionDownloadedListener = new PendingTransactionDownloadedListenerImpl(this);
         } catch (Exception e) {
             log.error("Could not initialize VeriBlock security", e);
             throw new RuntimeException(e);
         }
-
     }
 
     /**
      * Initialise context. This method should be call on the start app.
      *
      * @param networkParameters Config for particular network.
-     * @param peerDiscovery discovery peers.
-     * @param runAdminServer Start Admin RPC service. (It can be not necessary for tests.)
+     * @param peerDiscovery     discovery peers.
+     * @param runAdminServer    Start Admin RPC service. (It can be not necessary for tests.)
      */
-    public static synchronized void init(NetworkParameters networkParameters, PeerDiscovery peerDiscovery, boolean runAdminServer) {
+    public synchronized void init(NetworkParameters networkParameters, PeerDiscovery peerDiscovery, boolean runAdminServer) {
         init(networkParameters, new File("."), String.format("vbk-%s", networkParameters.getNetworkName()), peerDiscovery, runAdminServer);
     }
 
-    public static void shutdown(){
+    public void shutdown() {
         peerTable.shutdown();
-        if(server!= null) {
+        if (server != null) {
             server.shutdown();
         }
     }
 
-    private static Server createAdminServer() throws IOException, NumberFormatException {
-        InetSocketAddress rpcBindAddress = new InetSocketAddress(Context.getNetworkParameters().getAdminHost(), Context.getNetworkParameters().getAdminPort());
-        log.info("Starting Admin RPC service on {} with password {}", rpcBindAddress, Context.getNetworkParameters().getAdminPassword());
+    private Server createAdminServer() throws IOException, NumberFormatException {
+        InetSocketAddress rpcBindAddress = new InetSocketAddress(getNetworkParameters().getAdminHost(), getNetworkParameters().getAdminPort());
+        log.info("Starting Admin RPC service on {} with password {}", rpcBindAddress, getNetworkParameters().getAdminPassword());
 
-        return NettyServerBuilder
-                .forAddress(rpcBindAddress)
-                .addService(ServerInterceptors.intercept(adminService, adminServerInterceptor))
-                .build()
-                .start();
+        return NettyServerBuilder.forAddress(rpcBindAddress).addService(ServerInterceptors.intercept(adminService, adminServerInterceptor)).build()
+            .start();
     }
 
-    private static void init(VeriBlockStore veriBlockStore, NetworkParameters params){
+    private void init(VeriBlockStore veriBlockStore, NetworkParameters params) {
         try {
-            if(veriBlockStore.getChainHead() == null){
+            if (veriBlockStore.getChainHead() == null) {
                 VeriBlockBlock genesis = params.getGenesisBlock();
                 StoredVeriBlockBlock storedBlock = new StoredVeriBlockBlock(genesis, BitcoinUtilities.decodeCompactBits(genesis.getDifficulty()));
 
@@ -182,10 +178,9 @@ public class Context {
         }
     }
 
-
-    private static void init(BitcoinStore bitcoinStore, NetworkParameters params){
+    private void init(BitcoinStore bitcoinStore, NetworkParameters params) {
         try {
-            if(bitcoinStore.getChainHead() == null) {
+            if (bitcoinStore.getChainHead() == null) {
                 BitcoinBlock origin = params.getBitcoinOriginBlock();
                 StoredBitcoinBlock storedBlock = new StoredBitcoinBlock(origin, BitcoinUtilities.decodeCompactBits(origin.getBits()), 0);
 
@@ -197,79 +192,79 @@ public class Context {
         }
     }
 
-    public static   NetworkParameters getNetworkParameters() {
+    public NetworkParameters getNetworkParameters() {
         return networkParameters;
     }
 
-    public static File getDirectory() {
+    public File getDirectory() {
         return directory;
     }
 
-    public static String getFilePrefix() {
+    public String getFilePrefix() {
         return filePrefix;
     }
 
-    public static TransactionPool getTransactionPool() {
+    public TransactionPool getTransactionPool() {
         return transactionPool;
     }
 
-    public static VeriBlockStore getVeriBlockStore() {
+    public VeriBlockStore getVeriBlockStore() {
         return veriBlockStore;
     }
 
-    public static BitcoinStore getBitcoinStore() {
+    public BitcoinStore getBitcoinStore() {
         return bitcoinStore;
     }
 
-    public static AuditorChangesStore getAuditStore() {
+    public AuditorChangesStore getAuditStore() {
         return auditStore;
     }
 
-    public static Blockchain getBlockchain() {
+    public Blockchain getBlockchain() {
         return blockchain;
     }
 
-    public static Instant getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 
-    public static AdminApiService getAdminApiService() {
+    public AdminApiService getAdminApiService() {
         return adminApiService;
     }
 
-    public static AdminServiceFacade getAdminService() {
+    public AdminServiceFacade getAdminService() {
         return adminService;
     }
 
-    public static AdminServerInterceptor getAdminServerInterceptor() {
+    public AdminServerInterceptor getAdminServerInterceptor() {
         return adminServerInterceptor;
     }
 
-    public static PeerTable getPeerTable() {
+    public PeerTable getPeerTable() {
         return peerTable;
     }
 
-    public static P2PService getP2PService() {
+    public P2PService getP2PService() {
         return p2PService;
     }
 
-    public static Server getServer() {
+    public Server getServer() {
         return server;
     }
 
-    public static PendingTransactionDownloadedListener getPendingTransactionDownloadedListener() {
+    public PendingTransactionDownloadedListener getPendingTransactionDownloadedListener() {
         return pendingTransactionDownloadedListener;
     }
 
-    public static AddressManager getAddressManager() {
+    public AddressManager getAddressManager() {
         return addressManager;
     }
 
-    public static TransactionService getTransactionService() {
+    public TransactionService getTransactionService() {
         return transactionService;
     }
 
-    public static PendingTransactionContainer getPendingTransactionContainer() {
+    public PendingTransactionContainer getPendingTransactionContainer() {
         return pendingTransactionContainer;
     }
 }

--- a/nodecore-spv/src/main/java/veriblock/SpvContext.java
+++ b/nodecore-spv/src/main/java/veriblock/SpvContext.java
@@ -107,7 +107,7 @@ public class SpvContext {
 
             auditStore = new AuditorChangesStore(ConnectionSelector.setConnectionDefault());
             transactionPool = new TransactionPool();
-            blockchain = new Blockchain(networkParameters, veriBlockStore);
+            blockchain = new Blockchain(networkParameters.getGenesisBlock(), veriBlockStore);
 
             pendingTransactionContainer = new PendingTransactionContainerImpl();
             p2PService = new P2PServiceImpl(pendingTransactionContainer, networkParameters);

--- a/nodecore-spv/src/main/java/veriblock/model/PoPTransactionLight.java
+++ b/nodecore-spv/src/main/java/veriblock/model/PoPTransactionLight.java
@@ -15,6 +15,7 @@ import org.veriblock.sdk.models.MerklePath;
 import org.veriblock.sdk.models.Sha256Hash;
 import org.veriblock.sdk.models.VeriBlockBlock;
 import org.veriblock.sdk.services.SerializeDeserializeService;
+import veriblock.conf.NetworkParameters;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,7 +29,7 @@ public class PoPTransactionLight extends StandardTransaction {
     private BitcoinTransaction bitcoinTx;
     private MerklePath bitcoinMerklePath;
     private BitcoinBlock blockOfProof;
-    private List<BitcoinBlock> blockOfProofContext = new ArrayList<>();
+    private final List<BitcoinBlock> blockOfProofContext = new ArrayList<>();
 
     public PoPTransactionLight(Sha256Hash txId) {
         super(txId);
@@ -75,12 +76,12 @@ public class PoPTransactionLight extends StandardTransaction {
     }
 
     @Override
-    public byte[] toByteArray() {
+    public byte[] toByteArray(NetworkParameters networkParameters) {
         return calculateHash();
     }
 
     @Override
-    public VeriBlockMessages.SignedTransaction.Builder getSignedMessageBuilder() {
+    public VeriBlockMessages.SignedTransaction.Builder getSignedMessageBuilder(NetworkParameters networkParameters) {
         //TODO SPV-48
         return null;
     }

--- a/nodecore-spv/src/main/java/veriblock/model/Transaction.java
+++ b/nodecore-spv/src/main/java/veriblock/model/Transaction.java
@@ -9,6 +9,7 @@ package veriblock.model;
 
 import nodecore.api.grpc.VeriBlockMessages;
 import org.veriblock.sdk.models.Sha256Hash;
+import veriblock.conf.NetworkParameters;
 
 import java.util.List;
 
@@ -40,9 +41,9 @@ public abstract class Transaction {
 
     public abstract TransactionTypeIdentifier getTransactionTypeIdentifier();
 
-    public abstract byte[] toByteArray();
+    public abstract byte[] toByteArray(NetworkParameters networkParameters);
 
-    public abstract VeriBlockMessages.SignedTransaction.Builder getSignedMessageBuilder();
+    public abstract VeriBlockMessages.SignedTransaction.Builder getSignedMessageBuilder(NetworkParameters networkParameters);
 
     public final Sha256Hash getTxId() {
         return txId;

--- a/nodecore-spv/src/main/java/veriblock/net/LocalhostDiscovery.java
+++ b/nodecore-spv/src/main/java/veriblock/net/LocalhostDiscovery.java
@@ -7,9 +7,8 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 package veriblock.net;
 
-import veriblock.Context;
-import veriblock.model.PeerAddress;
 import veriblock.conf.NetworkParameters;
+import veriblock.model.PeerAddress;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -18,9 +17,14 @@ import java.util.Collections;
  * Discovery peer locally.
  */
 public class LocalhostDiscovery implements PeerDiscovery {
+    private final NetworkParameters networkParameters;
+
+    public LocalhostDiscovery(NetworkParameters networkParameters) {
+        this.networkParameters = networkParameters;
+    }
 
     @Override
     public Collection<PeerAddress> getPeers(int count) {
-        return Collections.singletonList(new PeerAddress(NetworkParameters.LOCALHOST, Context.getNetworkParameters().getP2pPort()));
+        return Collections.singletonList(new PeerAddress(NetworkParameters.LOCALHOST, networkParameters.getP2pPort()));
     }
 }

--- a/nodecore-spv/src/main/java/veriblock/net/impl/P2PServiceImpl.java
+++ b/nodecore-spv/src/main/java/veriblock/net/impl/P2PServiceImpl.java
@@ -5,6 +5,7 @@ import nodecore.api.grpc.VeriBlockMessages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.veriblock.sdk.models.Sha256Hash;
+import veriblock.conf.NetworkParameters;
 import veriblock.model.Transaction;
 import veriblock.net.P2PService;
 import veriblock.net.Peer;
@@ -16,10 +17,12 @@ import java.util.List;
 public class P2PServiceImpl implements P2PService {
     private static final Logger logger = LoggerFactory.getLogger(P2PServiceImpl.class);
 
-    private PendingTransactionContainer pendingTransactionContainer;
+    private final PendingTransactionContainer pendingTransactionContainer;
+    private final NetworkParameters networkParameters;
 
-    public P2PServiceImpl(PendingTransactionContainer pendingTransactionContainer) {
+    public P2PServiceImpl(PendingTransactionContainer pendingTransactionContainer, NetworkParameters networkParameters) {
         this.pendingTransactionContainer = pendingTransactionContainer;
+        this.networkParameters = networkParameters;
     }
 
     @Override
@@ -35,18 +38,16 @@ public class P2PServiceImpl implements P2PService {
 
                 switch (transaction.getTransactionTypeIdentifier()) {
                     case STANDARD:
-                        builder.setTransaction(VeriBlockMessages.TransactionUnion
-                                .newBuilder()
-                                .setSigned(transaction.getSignedMessageBuilder()));
+                        builder.setTransaction(
+                            VeriBlockMessages.TransactionUnion.newBuilder().setSigned(transaction.getSignedMessageBuilder(networkParameters)));
                         break;
                     case MULTISIG:
                         //TODO SPV-47
                         throw new UnsupportedOperationException();
 
                     case PROOF_OF_PROOF:
-                        builder.setTransaction(VeriBlockMessages.TransactionUnion
-                                .newBuilder()
-                                .setSigned(transaction.getSignedMessageBuilder()));
+                        builder.setTransaction(
+                            VeriBlockMessages.TransactionUnion.newBuilder().setSigned(transaction.getSignedMessageBuilder(networkParameters)));
                         break;
                 }
 

--- a/nodecore-spv/src/main/java/veriblock/service/impl/Blockchain.java
+++ b/nodecore-spv/src/main/java/veriblock/service/impl/Blockchain.java
@@ -14,7 +14,7 @@ import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock;
 import org.veriblock.sdk.blockchain.store.VeriBlockStore;
 import org.veriblock.sdk.models.VeriBlockBlock;
 import spark.utils.CollectionUtils;
-import veriblock.Context;
+import veriblock.conf.NetworkParameters;
 
 import java.math.BigInteger;
 import java.sql.SQLException;
@@ -31,9 +31,11 @@ import java.util.stream.Collectors;
 public class Blockchain {
     private static final Logger logger = LoggerFactory.getLogger(Blockchain.class);
 
+    private final NetworkParameters networkParameters;
     private final VeriBlockStore blockStore;
 
-    public Blockchain(VeriBlockStore blockStore) {
+    public Blockchain(NetworkParameters networkParameters, VeriBlockStore blockStore) {
+        this.networkParameters = networkParameters;
         this.blockStore = blockStore;
     }
 
@@ -168,7 +170,7 @@ public class Blockchain {
             logger.error("Unable to build peer query", e);
         }
 
-        blocks.add(Context.getNetworkParameters().getGenesisBlock());
+        blocks.add(networkParameters.getGenesisBlock());
 
         return blocks;
     }

--- a/nodecore-spv/src/main/java/veriblock/service/impl/Blockchain.java
+++ b/nodecore-spv/src/main/java/veriblock/service/impl/Blockchain.java
@@ -14,7 +14,6 @@ import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock;
 import org.veriblock.sdk.blockchain.store.VeriBlockStore;
 import org.veriblock.sdk.models.VeriBlockBlock;
 import spark.utils.CollectionUtils;
-import veriblock.conf.NetworkParameters;
 
 import java.math.BigInteger;
 import java.sql.SQLException;
@@ -31,11 +30,11 @@ import java.util.stream.Collectors;
 public class Blockchain {
     private static final Logger logger = LoggerFactory.getLogger(Blockchain.class);
 
-    private final NetworkParameters networkParameters;
+    private final VeriBlockBlock genesisBlock;
     private final VeriBlockStore blockStore;
 
-    public Blockchain(NetworkParameters networkParameters, VeriBlockStore blockStore) {
-        this.networkParameters = networkParameters;
+    public Blockchain(VeriBlockBlock genesisBlock, VeriBlockStore blockStore) {
+        this.genesisBlock = genesisBlock;
         this.blockStore = blockStore;
     }
 
@@ -170,7 +169,7 @@ public class Blockchain {
             logger.error("Unable to build peer query", e);
         }
 
-        blocks.add(networkParameters.getGenesisBlock());
+        blocks.add(genesisBlock);
 
         return blocks;
     }

--- a/nodecore-spv/src/main/java/veriblock/service/impl/TransactionFactoryImpl.java
+++ b/nodecore-spv/src/main/java/veriblock/service/impl/TransactionFactoryImpl.java
@@ -39,7 +39,7 @@ public class TransactionFactoryImpl implements TransactionFactory {
 
         Transaction transaction =
             new StandardTransaction(message.getTransaction().getSourceAddress().toString(), message.getTransaction().getSourceAmount(),
-                serializer.deserializeOutputes(message.getTransaction().getOutputsList()), message.getSignatureIndex(), networkParameters
+                serializer.deserializeOutputs(message.getTransaction().getOutputsList()), message.getSignatureIndex(), networkParameters
             );
 
         transaction.addSignature(message.getSignature().toByteArray(), message.getPublicKey().toByteArray());

--- a/nodecore-spv/src/main/java/veriblock/service/impl/TransactionFactoryImpl.java
+++ b/nodecore-spv/src/main/java/veriblock/service/impl/TransactionFactoryImpl.java
@@ -2,6 +2,7 @@ package veriblock.service.impl;
 
 import com.google.inject.Singleton;
 import nodecore.api.grpc.VeriBlockMessages;
+import veriblock.conf.NetworkParameters;
 import veriblock.model.StandardTransaction;
 import veriblock.model.Transaction;
 import veriblock.service.TransactionFactory;
@@ -9,6 +10,12 @@ import veriblock.wallet.WalletProtobufSerializer;
 
 @Singleton
 public class TransactionFactoryImpl implements TransactionFactory {
+
+    private final NetworkParameters networkParameters;
+
+    public TransactionFactoryImpl(NetworkParameters networkParameters) {
+        this.networkParameters = networkParameters;
+    }
 
     @Override
     public Transaction create(VeriBlockMessages.TransactionUnion message) {
@@ -30,11 +37,10 @@ public class TransactionFactoryImpl implements TransactionFactory {
     public Transaction create(VeriBlockMessages.SignedTransaction message) {
         WalletProtobufSerializer serializer = new WalletProtobufSerializer();
 
-        Transaction transaction = new StandardTransaction(
-                message.getTransaction().getSourceAddress().toString(),
-                message.getTransaction().getSourceAmount(),
-                serializer.deserializeOutputes(message.getTransaction().getOutputsList()),
-                message.getSignatureIndex());
+        Transaction transaction =
+            new StandardTransaction(message.getTransaction().getSourceAddress().toString(), message.getTransaction().getSourceAmount(),
+                serializer.deserializeOutputes(message.getTransaction().getOutputsList()), message.getSignatureIndex(), networkParameters
+            );
 
         transaction.addSignature(message.getSignature().toByteArray(), message.getPublicKey().toByteArray());
 

--- a/nodecore-spv/src/main/java/veriblock/service/impl/TransactionService.java
+++ b/nodecore-spv/src/main/java/veriblock/service/impl/TransactionService.java
@@ -13,6 +13,7 @@ import org.veriblock.core.crypto.Crypto;
 import org.veriblock.core.utilities.AddressUtility;
 import org.veriblock.core.utilities.Utility;
 import org.veriblock.sdk.models.Sha256Hash;
+import veriblock.conf.NetworkParameters;
 import veriblock.model.Output;
 import veriblock.model.SigningResult;
 import veriblock.model.StandardTransaction;
@@ -23,7 +24,7 @@ import java.util.List;
 
 public class TransactionService {
 
-    private AddressManager addressManager;
+    private final AddressManager addressManager;
 
     public TransactionService(AddressManager addressManager) {
         this.addressManager = addressManager;
@@ -39,17 +40,15 @@ public class TransactionService {
      * @return A StandardTransaction object
      */
     public Transaction createStandardTransaction(
-            String inputAddress,
-            Long inputAmount,
-            List<Output> outputs,
-            Long signatureIndex) {
+        String inputAddress, Long inputAmount, List<Output> outputs, Long signatureIndex, NetworkParameters networkParameters
+    ) {
         if (inputAddress == null) {
             throw new IllegalArgumentException("createStandardTransaction cannot be called with a null inputAddress!");
         }
 
         if (!AddressUtility.isValidStandardAddress(inputAddress)) {
-            throw new IllegalArgumentException("createStandardTransaction cannot be called with an invalid " +
-                    "inputAddress (" + inputAddress + ")!");
+            throw new IllegalArgumentException(
+                "createStandardTransaction cannot be called with an invalid " + "inputAddress (" + inputAddress + ")!");
         }
 
         if (!Utility.isPositive(inputAmount)) {
@@ -81,11 +80,7 @@ public class TransactionService {
                     inputAmount + ")!");
         }
 
-        Transaction transaction = new StandardTransaction(
-                inputAddress,
-                inputAmount,
-                outputs,
-                signatureIndex);
+        Transaction transaction = new StandardTransaction(inputAddress, inputAmount, outputs, signatureIndex, networkParameters);
 
         SigningResult signingResult = signTransaction(transaction.getTxId(), inputAddress);
 
@@ -132,9 +127,8 @@ public class TransactionService {
         return totalSize;
     }
 
-
-    public static Sha256Hash calculateTxID(Transaction transaction) {
-        return Sha256Hash.wrap(calculateTxIDBytes(transaction.toByteArray()));
+    public static Sha256Hash calculateTxID(Transaction transaction, NetworkParameters networkParameters) {
+        return Sha256Hash.wrap(calculateTxIDBytes(transaction.toByteArray(networkParameters)));
     }
 
     public static byte[] calculateTxIDBytes(byte[] rawTx) {

--- a/nodecore-spv/src/main/java/veriblock/wallet/PendingTransactionDownloadedListenerImpl.java
+++ b/nodecore-spv/src/main/java/veriblock/wallet/PendingTransactionDownloadedListenerImpl.java
@@ -1,7 +1,7 @@
 package veriblock.wallet;
 
 import org.veriblock.sdk.models.Sha256Hash;
-import veriblock.Context;
+import veriblock.SpvContext;
 import veriblock.listeners.PendingTransactionDownloadedListener;
 import veriblock.model.StandardTransaction;
 import veriblock.model.TransactionMeta;
@@ -12,13 +12,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class PendingTransactionDownloadedListenerImpl  implements PendingTransactionDownloadedListener {
+public class PendingTransactionDownloadedListenerImpl implements PendingTransactionDownloadedListener {
+
+    private final SpvContext spvContext;
 
     private Map<Sha256Hash, StandardTransaction> transactions;
     private final Ledger ledger = new Ledger();
 
     private final KeyRing keyRing = new KeyRing();
     private final ReentrantLock lock = new ReentrantLock(true);
+
+    public PendingTransactionDownloadedListenerImpl(SpvContext spvContext) {
+        this.spvContext = spvContext;
+    }
 
     @Override
     public void onPendingTransactionDownloaded(StandardTransaction transaction) {
@@ -28,7 +34,7 @@ public class PendingTransactionDownloadedListenerImpl  implements PendingTransac
     void loadTransactions(List<StandardTransaction> toLoad) {
         for (StandardTransaction tx : toLoad) {
             transactions.put(tx.getTxId(), tx);
-            Context.getTransactionPool().insert(tx.getTransactionMeta());
+            spvContext.getTransactionPool().insert(tx.getTransactionMeta());
         }
     }
 

--- a/nodecore-spv/src/main/java/veriblock/wallet/WalletProtobufSerializer.java
+++ b/nodecore-spv/src/main/java/veriblock/wallet/WalletProtobufSerializer.java
@@ -26,10 +26,8 @@ import java.util.stream.Collectors;
 public class WalletProtobufSerializer {
     private static final Logger logger = LoggerFactory.getLogger(WalletProtobufSerializer.class);
 
-    public List<Output> deserializeOutputes(List<VeriBlockMessages.Output> output) {
-        List<Output> outputs = output.stream()
-                .map(out -> deserialize(out))
-                .collect(Collectors.toList());
+    public List<Output> deserializeOutputs(List<VeriBlockMessages.Output> output) {
+        List<Output> outputs = output.stream().map(out -> deserialize(out)).collect(Collectors.toList());
 
         return outputs;
     }

--- a/nodecore-spv/src/test/java/veriblock/lite/core/StandardTransactionTest.java
+++ b/nodecore-spv/src/test/java/veriblock/lite/core/StandardTransactionTest.java
@@ -7,21 +7,22 @@ import org.junit.Before;
 import org.junit.Test;
 import org.veriblock.core.utilities.Utility;
 import org.veriblock.sdk.models.Coin;
-import veriblock.Context;
+import veriblock.SpvContext;
+import veriblock.conf.MainNetParameters;
 import veriblock.model.Output;
 import veriblock.model.StandardAddress;
 import veriblock.model.StandardTransaction;
 import veriblock.net.LocalhostDiscovery;
-import veriblock.conf.MainNetParameters;
 
 import java.util.ArrayList;
 
 public class StandardTransactionTest {
 
+    private final SpvContext spvContext = new SpvContext();
 
     @Before
     public void setUp() {
-        Context.init(MainNetParameters.get(), new LocalhostDiscovery(), false);
+        spvContext.init(MainNetParameters.get(), new LocalhostDiscovery(MainNetParameters.get()), false);
     }
 
     @Test
@@ -29,13 +30,14 @@ public class StandardTransactionTest {
         ArrayList<Output> outputs = new ArrayList<>();
         outputs.add(new Output(new StandardAddress("V7GghFKRA6BKqtHD7LTdT2ao93DRNA"), Coin.valueOf(3499999999L)));
 
-        StandardTransaction tx = new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L,outputs, 5904L);
+        StandardTransaction tx =
+            new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L, outputs, 5904L, spvContext.getNetworkParameters());
 
         byte[] pub = new byte[]{1,2,3};
         byte[] sign = new byte[]{3,2,1};
         tx.addSignature(sign,pub);
 
-        VeriBlockMessages.SignedTransaction signedTransaction = tx.getSignedMessageBuilder().build();
+        VeriBlockMessages.SignedTransaction signedTransaction = tx.getSignedMessageBuilder(spvContext.getNetworkParameters()).build();
 
         Assert.assertEquals(5904L, signedTransaction.getSignatureIndex());
         Assert.assertEquals(3500000000L, signedTransaction.getTransaction().getSourceAmount());
@@ -52,9 +54,10 @@ public class StandardTransactionTest {
         ArrayList<Output> outputs = new ArrayList<>();
         outputs.add(new Output(new StandardAddress("V7GghFKRA6BKqtHD7LTdT2ao93DRNA"), Coin.valueOf(3499999999L)));
 
-        StandardTransaction tx = new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L,outputs, 5904L);
+        StandardTransaction tx =
+            new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L, outputs, 5904L, spvContext.getNetworkParameters());
 
-        byte[] serialized = tx.toByteArray();
+        byte[] serialized = tx.toByteArray(spvContext.getNetworkParameters());
 
         Assert.assertEquals("01011667A654EE3E0C918D8652B63829D7F3BEF98524BF899604D09DC30001011667901A1E11C650509EFC46E09E81678054D8562AF02B04D09DC2FF0217100100", Utility.bytesToHex(serialized));
     }

--- a/nodecore-spv/src/test/java/veriblock/net/impl/P2PServiceImplTest.java
+++ b/nodecore-spv/src/test/java/veriblock/net/impl/P2PServiceImplTest.java
@@ -4,13 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.veriblock.sdk.models.Coin;
 import org.veriblock.sdk.models.Sha256Hash;
-import veriblock.Context;
+import veriblock.SpvContext;
+import veriblock.conf.TestNetParameters;
 import veriblock.model.Output;
 import veriblock.model.StandardAddress;
 import veriblock.model.StandardTransaction;
 import veriblock.net.LocalhostDiscovery;
 import veriblock.net.Peer;
-import veriblock.conf.TestNetParameters;
 import veriblock.service.PendingTransactionContainer;
 
 import java.util.ArrayList;
@@ -25,17 +25,19 @@ import static org.mockito.Mockito.when;
 
 public class P2PServiceImplTest {
 
+    private final SpvContext spvContext = new SpvContext();
+
     private PendingTransactionContainer pendingTransactionContainer;
     private Peer peer;
     private P2PServiceImpl p2PService;
 
     @Before
     public void setUp() {
-        Context.init(TestNetParameters.get(), new LocalhostDiscovery(), false);
+        spvContext.init(TestNetParameters.get(), new LocalhostDiscovery(TestNetParameters.get()), false);
 
         this.pendingTransactionContainer = mock(PendingTransactionContainer.class);
         this.peer = mock(Peer.class);
-        this.p2PService = new P2PServiceImpl(pendingTransactionContainer);
+        this.p2PService = new P2PServiceImpl(pendingTransactionContainer, spvContext.getNetworkParameters());
     }
 
     @Test
@@ -59,8 +61,9 @@ public class P2PServiceImplTest {
 
         ArrayList<Output> outputs = new ArrayList<>();
         outputs.add(new Output(new StandardAddress("V7GghFKRA6BKqtHD7LTdT2ao93DRNA"), Coin.valueOf(3499999999L)));
-        StandardTransaction standardTransaction = new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L,outputs, 5904L);
-        byte[] pub = new byte[]{1,2,3};
+        StandardTransaction standardTransaction =
+            new StandardTransaction("V8dy5tWcP7y36kxiJwxKPKUrWAJbjs", 3500000000L, outputs, 5904L, spvContext.getNetworkParameters());
+        byte[] pub = new byte[]{1, 2, 3};
         byte[] sign = new byte[]{3,2,1};
         standardTransaction.addSignature(sign,pub);
 


### PR DESCRIPTION
* Context renamed to SpvContext for clarity.
* Not all unit tests will need the whole context to be initialized now.
* We will be able to support different contexts concurrently (after junit 5 tests are able to run in parallel).
* Leaving better state control to the library user, letting them keep the context wherever they prefer instead of global state.
* Some functions now require an extra annoying parameter. This can be solved with wrapper services which hold the context.