### PR TITLE
Precalculate hash in parallel & cache it

### DIFF
--- a/nodecore-spv/src/main/java/veriblock/net/SpvPeerTable.kt
+++ b/nodecore-spv/src/main/java/veriblock/net/SpvPeerTable.kt
@@ -96,6 +96,7 @@ class SpvPeerTable(
     private val pendingPeers = ConcurrentHashMap<String, SpvPeer>()
     private val incomingQueue: Channel<NetworkMessage> = Channel(UNLIMITED)
 
+    private val hashDispatcher = Threading.HASH_EXECUTOR.asCoroutineDispatcher();
     private val coroutineDispatcher = Threading.PEER_TABLE_THREAD.asCoroutineDispatcher()
     private val coroutineScope = CoroutineScope(coroutineDispatcher)
 
@@ -286,7 +287,7 @@ class SpvPeerTable(
                         }
                         val veriBlockBlocks: List<VeriBlockBlock> = coroutineScope {
                             advertiseBlocks.headersList.map {
-                                async(Threading.HASH_EXECUTOR.asCoroutineDispatcher()) {
+                                async(hashDispatcher) {
                                     val block = MessageSerializer.deserialize(it)
                                     // pre-calculate hash in parallel
                                     block.hash

--- a/nodecore-spv/src/main/java/veriblock/util/Threading.kt
+++ b/nodecore-spv/src/main/java/veriblock/util/Threading.kt
@@ -49,7 +49,7 @@ object Threading {
             .build()
     )
     val HASH_EXECUTOR: ExecutorService = Executors.newFixedThreadPool(
-        4, // TODO: how to get number of CPUs here?
+        Runtime.getRuntime().availableProcessors(),
         ThreadFactoryBuilder()
             .setNameFormat("progpow-%d")
             .build()

--- a/nodecore-spv/src/main/java/veriblock/util/Threading.kt
+++ b/nodecore-spv/src/main/java/veriblock/util/Threading.kt
@@ -68,7 +68,8 @@ object Threading {
             CompletableFuture.runAsync { shutdown(MESSAGE_HANDLER_THREAD) },
             CompletableFuture.runAsync { shutdown(PEER_OUTPUT_POOL) },
             CompletableFuture.runAsync { shutdown(PEER_INPUT_POOL) },
-            CompletableFuture.runAsync { shutdown(EVENT_EXECUTOR) }
+            CompletableFuture.runAsync { shutdown(EVENT_EXECUTOR) },
+            CompletableFuture.runAsync { shutdown(HASH_EXECUTOR) },
         )
         shutdownTasks.get()
     }

--- a/nodecore-spv/src/main/java/veriblock/util/Threading.kt
+++ b/nodecore-spv/src/main/java/veriblock/util/Threading.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.lang.Runtime
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
@@ -45,6 +46,12 @@ object Threading {
         25,
         ThreadFactoryBuilder()
             .setNameFormat("peer-input-%d")
+            .build()
+    )
+    val HASH_EXECUTOR: ExecutorService = Executors.newFixedThreadPool(
+        4, // TODO: how to get number of CPUs here?
+        ThreadFactoryBuilder()
+            .setNameFormat("progpow-%d")
             .build()
     )
     val EVENT_EXECUTOR: ExecutorService = Executors.newSingleThreadExecutor(


### PR DESCRIPTION
This code further improves blockchain downloading time, from 32 min to 18 min (in APM+SPV, testnet) by pre-calculating block hash in a thread pool. 