### PR TITLE
Refactor Blockchain, BlockStore, add Chain

### DIFF
--- a/nodecore-spv/src/main/java/org/veriblock/spv/SpvContext.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/SpvContext.kt
@@ -89,7 +89,7 @@ class SpvContext {
             filePrefix = filePr
             blockStore = BlockStore(networkParameters, directory)
             transactionPool = TransactionPool()
-            blockchain = Blockchain(networkParam, blockStore)
+            blockchain = Blockchain(blockStore)
             pendingTransactionContainer = PendingTransactionContainer()
             p2PService = P2PService(pendingTransactionContainer, networkParameters)
             addressManager = AddressManager()

--- a/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeer.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeer.kt
@@ -152,7 +152,8 @@ class SpvPeer(
          * 6. Allow the advertise to pass through to the handler for adding to blockchain
          * 7. If it was the maximum number of advertisements though, send another keystone query
          */
-        requestBlockDownload(blockchain.getPeerQuery())
+        val query = blockchain.getPeerQuery()
+        requestBlockDownload(query)
     }
 
     fun setFilter(filter: BloomFilter) {
@@ -172,6 +173,9 @@ class SpvPeer(
     }
 
     private fun requestBlockDownload(keystones: List<VeriBlockBlock>) {
+        if(keystones.isEmpty()) {
+            throw IllegalArgumentException("Keystones array can not be empty!")
+        }
         val queryBuilder = KeystoneQuery.newBuilder()
         for (block in keystones) {
             logger.debug { "Preparing keystone ${block.height}..." }

--- a/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeer.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeer.kt
@@ -174,7 +174,7 @@ class SpvPeer(
 
     private fun requestBlockDownload(keystones: List<VeriBlockBlock>) {
         if(keystones.isEmpty()) {
-            throw IllegalArgumentException("Keystones array can not be empty!")
+            throw IllegalArgumentException("Trying to request block download with empty keystones!")
         }
         val queryBuilder = KeystoneQuery.newBuilder()
         for (block in keystones) {

--- a/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeerTable.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeerTable.kt
@@ -118,16 +118,12 @@ class SpvPeerTable(
     fun start() {
         running.set(true)
 
-        SpvEventBus.newBestBlockEvent.register(this) {
-            // on every best block change, attempt to request our balance
-            requestAddressState()
-        }
         SpvEventBus.peerConnectedEvent.register(this, ::onPeerConnected)
         SpvEventBus.peerDisconnectedEvent.register(this, ::onPeerDisconnected)
         SpvEventBus.messageReceivedEvent.register(this) {
             onMessageReceived(it.message, it.peer)
         }
-        coroutineScope.launchWithFixedDelay(30_000L, 20_000L) {
+        coroutineScope.launchWithFixedDelay(10_000L, 10_000L) {
             requestAddressState()
         }
         coroutineScope.launchWithFixedDelay(200L, 20_000L) {

--- a/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeerTable.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/net/SpvPeerTable.kt
@@ -84,6 +84,7 @@ class SpvPeerTable(
 ) {
     private val lock = ReentrantLock()
     private val running = AtomicBoolean(false)
+    private val requestingLedgerProof = AtomicBoolean(false)
     private val discovery: PeerDiscovery
     private val blockchain: Blockchain
     var maximumPeers = DEFAULT_CONNECTIONS
@@ -117,12 +118,16 @@ class SpvPeerTable(
     fun start() {
         running.set(true)
 
+        SpvEventBus.newBestBlockEvent.register(this) {
+            // on every best block change, attempt to request our balance
+            requestAddressState()
+        }
         SpvEventBus.peerConnectedEvent.register(this, ::onPeerConnected)
         SpvEventBus.peerDisconnectedEvent.register(this, ::onPeerDisconnected)
         SpvEventBus.messageReceivedEvent.register(this) {
             onMessageReceived(it.message, it.peer)
         }
-        coroutineScope.launchWithFixedDelay (30_000L, 60_000L){
+        coroutineScope.launchWithFixedDelay(30_000L, 20_000L) {
             requestAddressState()
         }
         coroutineScope.launchWithFixedDelay(200L, 20_000L) {
@@ -194,11 +199,19 @@ class SpvPeerTable(
     }
 
     private suspend fun requestAddressState() {
-        val addresses = spvContext.addressManager.getAll()
-        if (addresses.isEmpty()) {
+        // if requestingLedgerProof is true, then we already started requesting our balance, skip this call.
+        // this prevents SPV from sending too many requests when new block is changed very quickly.
+        if (requestingLedgerProof.get()) {
             return
         }
+        requestingLedgerProof.set(true)
+
         try {
+            val addresses = spvContext.addressManager.all
+            if (addresses.isEmpty()) {
+                return
+            }
+
             val request = buildMessage {
                 ledgerProofRequest = LedgerProofRequest.newBuilder().apply {
                     for (address in addresses) {
@@ -220,6 +233,8 @@ class SpvPeerTable(
         } catch (e: Exception) {
             logger.debugWarn(e) { "Unable to request address state" }
         }
+
+        requestingLedgerProof.set(false)
     }
 
     private suspend fun requestPendingTransactions() {
@@ -459,7 +474,7 @@ class SpvPeerTable(
 
     fun getDownloadStatus(): DownloadStatusResponse {
         val status: DownloadStatus
-        val currentHeight = blockchain.getChainHead().height
+        val currentHeight = blockchain.activeChain.tip.height
         val bestBlockHeight = downloadPeer?.bestBlockHeight ?: 0
         status = when {
             downloadPeer == null || (currentHeight == 0 && bestBlockHeight == 0) ->

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
@@ -4,7 +4,7 @@ import org.veriblock.core.crypto.PreviousBlockVbkHash
 import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
 
 data class BlockIndex(
-    val hash: PreviousBlockVbkHash,
+    val smallHash: PreviousBlockVbkHash,
     val position: Long,
     val height: Int,
     // for fast access of previous block

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
@@ -1,0 +1,30 @@
+package org.veriblock.spv.service
+
+import org.veriblock.core.crypto.PreviousBlockVbkHash
+import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
+
+data class BlockIndex(
+    val hash: PreviousBlockVbkHash,
+    val position: Long,
+    val height: Int,
+    // for fast access of previous block
+    val prev: BlockIndex? = null
+) {
+    fun getAncestorAtHeight(height: Int): BlockIndex? {
+        if (height < 0 || height > this.height) {
+            return null
+        }
+
+        // in O(n) seek backwards until we hit valid height
+        var cursor: BlockIndex? = this
+        while (cursor != null && cursor.height > height) {
+            cursor = cursor.prev
+        }
+
+        return cursor
+    }
+
+    fun readBlock(store: BlockStore): StoredVeriBlockBlock? {
+        return store.readBlock(position)
+    }
+}

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
@@ -3,6 +3,8 @@ package org.veriblock.spv.service
 import org.veriblock.core.crypto.PreviousBlockVbkHash
 import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
 
+const val KEYSTONE_INTERVAL = 20
+
 data class BlockIndex(
     val smallHash: PreviousBlockVbkHash,
     val position: Long,
@@ -27,4 +29,29 @@ data class BlockIndex(
     fun readBlock(store: BlockStore): StoredVeriBlockBlock? {
         return store.readBlock(position)
     }
+
+    val isKeystone: Boolean
+        get() {
+            return height % KEYSTONE_INTERVAL == 0
+        }
+
+    val previousKeystone: BlockIndex?
+        get() {
+            // start with previous block
+            var cursor = this.prev
+            while (cursor != null && !cursor.isKeystone) {
+                cursor = cursor.prev
+            }
+            return cursor
+        }
+
+    val secondPreviousKeystone: BlockIndex?
+        get() {
+            // start with previous block of previous keystone
+            var cursor = this.previousKeystone?.prev
+            while (cursor != null && !cursor.isKeystone) {
+                cursor = cursor.prev
+            }
+            return cursor
+        }
 }

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockIndex.kt
@@ -31,9 +31,7 @@ data class BlockIndex(
     }
 
     val isKeystone: Boolean
-        get() {
-            return height % KEYSTONE_INTERVAL == 0
-        }
+        get() = height % KEYSTONE_INTERVAL == 0
 
     val previousKeystone: BlockIndex?
         get() {

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockStore.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockStore.kt
@@ -22,6 +22,10 @@ import kotlin.concurrent.withLock
 
 private val logger = createLogger {}
 
+/**
+ * @invariant blocks.db file contains only connected blocks. I.e. store never
+ * contains a block whose previousBlock does not exist in this store **before** this block.
+ */
 class BlockStore(
     private val networkParameters: NetworkParameters,
     baseDir: File

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockStore.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/BlockStore.kt
@@ -166,7 +166,7 @@ class BlockStore(
         val prev = blockIndex[block.header.previousBlock]
         // this invariant should never fail with correct usage of this func
             ?: throw IllegalStateException(
-                "Invariant failed! Can append to block index blocks that connect to block index."
+                "Invariant failed! The block $block does not connect to the block index."
             )
 
         val index = BlockIndex(

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/Blockchain.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/Blockchain.kt
@@ -9,36 +9,125 @@ package org.veriblock.spv.service
 
 import org.veriblock.core.bitcoinj.BitcoinUtilities
 import org.veriblock.core.crypto.AnyVbkHash
+import org.veriblock.core.crypto.PreviousBlockVbkHash
+import org.veriblock.core.params.NetworkParameters
 import org.veriblock.core.utilities.createLogger
 import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
 import org.veriblock.sdk.models.VeriBlockBlock
 import org.veriblock.sdk.services.ValidationService
 import org.veriblock.spv.util.SpvEventBus
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
 import java.lang.IllegalStateException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 private val logger = createLogger {}
 
 class Blockchain(
-    private val blockStore: BlockStore
+    val blockStore: BlockStore
 ) {
-
-    val activeChain get() = blockStore.activeChain
-    val blockIndex get() = blockStore.blockIndex
+    // in-memory block index
+    val blockIndex = ConcurrentHashMap<PreviousBlockVbkHash, BlockIndex>()
+    lateinit var activeChain: Chain
     val size get() = blockIndex.size
 
-    fun getChainHeadBlock(): StoredVeriBlockBlock {
-        return blockStore.getChainHeadBlock()
+    init {
+        reindex()
     }
 
+    /**
+     * Drop existing block index, and re-generate one from disk.
+     */
+    fun reindex() {
+        logger.info { "Reading $${blockStore.networkParameters} blocks..." }
+
+        // drop previous block index
+        blockIndex.clear()
+        writeGenesisBlock(blockStore.networkParameters.genesisBlock)
+
+        // reads blocks file and builds block index
+        blockStore.forEach { position, block ->
+            // we were able to read a block from blocks file.
+            // this block must connect to previous block, i.e.
+            // previous block must exist in index
+
+            val prevHash = block.header.previousBlock
+            val prevIndex = blockIndex[prevHash]
+            // ignore genesis block
+            if (block.height != 0 && prevIndex == null) {
+                logger.warn { "Found block that does not connect to blockchain: height=${block.height} hash=${block.hash} " }
+                return@forEach false
+            }
+
+            // prev index exists! this is valid block
+            val index = appendToBlockIndex(position, block)
+
+            // update active chain
+            if (activeChain.tipWork < block.work) {
+                activeChain.setTip(index, block.work)
+            }
+
+            true
+        }
+
+        logger.info { "Successfully initialized Blockchain with ${blockIndex.size} blocks" }
+    }
+
+
+    /**
+     * Getter for block index.
+     */
+    fun getBlockIndex(hash: AnyVbkHash): BlockIndex? = blockIndex[hash.trimToPreviousBlockSize()]
+    fun getBlockIndex(height: Int): BlockIndex? = activeChain[height]
+
+    /**
+     * Getter for tip.
+     */
+    fun getChainHeadBlock(): StoredVeriBlockBlock = blockStore.readBlock(activeChain.tip.position)!!
+    fun getChainHeadIndex(): BlockIndex = activeChain.tip
+
+    /**
+     * Reads block with given hash.
+     */
     fun getBlock(hash: AnyVbkHash): StoredVeriBlockBlock? {
-        return blockStore.readBlock(hash)
+        val smallHash = hash.trimToPreviousBlockSize()
+        val index = blockIndex[smallHash] ?: return null
+        return blockStore.readBlock(index.position)
     }
 
-    fun getBlockIndex(hash: AnyVbkHash): BlockIndex? {
-        return blockStore.getBlockIndex(hash)
+    /**
+     * Reads block with given height on active chain.
+     */
+    fun getBlock(height: Int): StoredVeriBlockBlock? {
+        val index = activeChain[height] ?: return null
+        return blockStore.readBlock(index.position)
     }
 
-    fun acceptBlock(block: VeriBlockBlock): Boolean {
+    /**
+     * Reads a chain of blocks from active chain of given `size` ending with `hash`
+     */
+    fun getChainWithTip(hash: AnyVbkHash, size: Int): ArrayList<StoredVeriBlockBlock> {
+        val ret = ArrayList<StoredVeriBlockBlock>()
+        var i = 0
+        var cursor = getBlock(hash)
+        while (cursor != null && i++ < size) {
+            ret.add(cursor)
+            cursor = getBlock(cursor.header.previousBlock)
+        }
+        ret.reverse()
+        return ret
+    }
+
+    /**
+     * Adds new block to Blockchain.
+     * @return true if block is valid, false otherwise
+     */
+    fun acceptBlock(
+        block: VeriBlockBlock
+    ): Boolean {
         if (getBlockIndex(block.hash) != null) {
             // block is valid, we already have it
             return true
@@ -75,12 +164,13 @@ class Blockchain(
         // TODO: contextually check block: validate median time past, validate keystones
 
         // write block on disk
-        val index = blockStore.appendBlock(stored)
+        val position = blockStore.appendBlock(stored)
+        val index = appendToBlockIndex(position, stored)
 
         // do fork resolution
-        if (stored.work > blockStore.activeChain.tipWork) {
+        if (stored.work > activeChain.tipWork) {
             // new block wins
-            blockStore.activeChain.setTip(index, stored.work)
+            activeChain.setTip(index, stored.work)
             SpvEventBus.newBestBlockEvent.trigger(block)
         }
 
@@ -91,9 +181,50 @@ class Blockchain(
     }
 
     fun getPeerQuery(): List<VeriBlockBlock> {
-        return blockStore
-            .readChainWithTip(blockStore.activeChain.tip.smallHash, 100)
+        return getChainWithTip(activeChain.tip.smallHash, 100)
             .map { it.header }
             .filter { it.isKeystone() }
+    }
+
+    private fun appendToBlockIndex(position: Long, block: StoredVeriBlockBlock): BlockIndex {
+        val smallHash = block.hash.trimToPreviousBlockSize()
+        val prev = blockIndex[block.header.previousBlock]
+        val index = BlockIndex(
+            smallHash = smallHash,
+            position = position,
+            height = block.height,
+            prev = prev
+        )
+        blockIndex[smallHash] = index
+        return index
+    }
+
+    private fun writeGenesisBlock(genesis: VeriBlockBlock) {
+        val smallHash = genesis.hash.trimToPreviousBlockSize()
+        val param = blockStore.networkParameters
+        val work = BitcoinUtilities.decodeCompactBits(
+            param.genesisBlock.difficulty.toLong()
+        )
+
+        // write gb to position 0
+        blockStore.writeBlock(
+            position = 0,
+            block = StoredVeriBlockBlock(
+                header = param.genesisBlock,
+                work = work,
+                hash = param.genesisBlock.hash
+            )
+        )
+
+        // block index always contains genesis block on start
+        val index = BlockIndex(
+            smallHash = smallHash,
+            position = 0, // gb is at position 0
+            height = 0,
+            prev = null
+        )
+
+        blockIndex[smallHash] = index
+        activeChain = Chain(index, work)
     }
 }

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/Chain.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/Chain.kt
@@ -14,7 +14,7 @@ class Chain(
     }
 
     // get by height
-    fun get(index: Int): BlockIndex? {
+    operator fun get(index: Int): BlockIndex? {
         if (index < 0 || index >= chain.size) return null
         return chain[index]
     }
@@ -40,7 +40,7 @@ class Chain(
         chain.ensureCapacity(block.height + 1)
 
         // FIXME: workaround for ArrayList to allow usage of operator[] in next while loop
-        while(chain.size <= block.height) {
+        while (chain.size <= block.height) {
             // this `block` will be overwritten in the next loop anyway
             chain.add(block)
         }

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/Chain.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/Chain.kt
@@ -1,0 +1,76 @@
+package org.veriblock.spv.service
+
+import java.math.BigInteger
+
+class Chain(
+    tip: BlockIndex,
+    // cached cumulative work of current tip
+    var tipWork: BigInteger
+) {
+    private var chain = ArrayList<BlockIndex>()
+
+    init {
+        chain.add(tip)
+    }
+
+    // get by height
+    fun get(index: Int): BlockIndex? {
+        if (index < 0 || index >= chain.size) return null
+        return chain[index]
+    }
+
+    fun contains(block: BlockIndex): Boolean {
+        val inner = get(block.height)
+        return inner == block
+    }
+
+    val tip: BlockIndex
+        get() = chain[chain.size - 1]
+
+    val first: BlockIndex
+        get() = chain[0]
+
+    fun setTip(block: BlockIndex, cumulativeWork: BigInteger) {
+        tipWork = cumulativeWork
+        if (chain.isNotEmpty() && tip == block.prev) {
+            chain.add(block)
+            return
+        }
+
+        chain.ensureCapacity(block.height + 1)
+
+        // FIXME: workaround for ArrayList to allow usage of operator[] in next while loop
+        while(chain.size <= block.height) {
+            // this `block` will be overwritten in the next loop anyway
+            chain.add(block)
+        }
+
+        var cursor: BlockIndex? = block
+        while (cursor != null && !contains(cursor)) {
+            chain[cursor.height] = cursor
+            cursor = cursor.prev
+        }
+    }
+
+    // finds a fork between current tip and a block
+    fun findFork(block: BlockIndex, maxSearchDistance: Int = Integer.MAX_VALUE): BlockIndex? {
+        var cursor: BlockIndex? = null
+        val lastHeight = tip.height
+        if (block.height > lastHeight) {
+            cursor = block.getAncestorAtHeight(lastHeight)
+        }
+        var i = 0
+        while (cursor != null && !contains(cursor) && i++ < maxSearchDistance) {
+            cursor = cursor.prev
+        }
+        return cursor
+    }
+
+    fun getLast(n: Int): List<BlockIndex> {
+        if (n > chain.size) {
+            return chain
+        }
+
+        return chain.subList(chain.size - n, chain.size)
+    }
+}

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/SpvService.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/SpvService.kt
@@ -69,13 +69,13 @@ class SpvService(
             operatingState = operatingState,
             networkState = networkState,
             connectedPeerCount = peerTable.getAvailablePeers(),
-            networkHeight = peerTable.getBestBlockHeight().coerceAtLeast(blockchain.getChainHead().height),
-            localBlockchainHeight = blockchain.getChainHead().height,
+            networkHeight = peerTable.getBestBlockHeight().coerceAtLeast(blockchain.activeChain.tip.height),
+            localBlockchainHeight = blockchain.activeChain.tip.height,
             networkVersion = spvContext.networkParameters.name,
             dataDirectory = spvContext.directory.path,
             programVersion = Constants.PROGRAM_VERSION ?: "UNKNOWN",
             nodecoreStartTime = spvContext.startTime.epochSecond,
-            walletCacheSyncHeight = blockchain.getChainHead().height,
+            walletCacheSyncHeight = blockchain.activeChain.tip.height,
             walletState = when {
                 addressManager.isEncrypted -> WalletState.DEFAULT
                 addressManager.isLocked -> WalletState.LOCKED
@@ -346,7 +346,7 @@ class SpvService(
     }
 
     fun getLastVBKBlockHeader(): BlockHeader {
-        val block: StoredVeriBlockBlock = blockchain.getChainHead()
+        val block: StoredVeriBlockBlock = blockchain.getChainHeadBlock()
         return BlockHeader(
             SerializeDeserializeService.serializeHeaders(block.header),
             block.hash.bytes
@@ -354,7 +354,7 @@ class SpvService(
     }
 
     fun getVbkBlockHeader(hash: AnyVbkHash): BlockHeader? {
-        val block = blockchain.get(hash)
+        val block = blockchain.getBlock(hash)
             ?: return null
         return BlockHeader(
             SerializeDeserializeService.serializeHeaders(block.header),

--- a/nodecore-spv/src/main/java/org/veriblock/spv/service/Util.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/service/Util.kt
@@ -1,34 +1,6 @@
 package org.veriblock.spv.service
 
-import org.veriblock.core.bitcoinj.BitcoinUtilities
-import org.veriblock.core.crypto.Sha256Hash
-import org.veriblock.core.crypto.VBlakeHash
-import org.veriblock.core.params.NetworkParameters
-import org.veriblock.sdk.blockchain.VeriBlockDifficultyCalculator
-import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
-import org.veriblock.sdk.models.VeriBlockBlock
-import org.veriblock.sdk.services.ValidationService
-import kotlin.math.max
-
-// returns ancestor of `this` at height `height`
-fun StoredVeriBlockBlock.getAncestorAtHeight(
-    height: Int,
-    blockStore: BlockStore
-): StoredVeriBlockBlock? {
-    if (height < 0 || height > this.height) {
-        return null
-    }
-
-    // in O(n) seek backwards until we hit valid height
-    var cursor: StoredVeriBlockBlock? = this
-    while (cursor != null && cursor.height > height) {
-        cursor = blockStore.readBlock(cursor.header.previousBlock)
-    }
-
-    return cursor
-}
-
-class StatefulIterable<out T>(wrapped: Sequence<T>): Iterable<T> {
+class StatefulIterable<out T>(wrapped: Sequence<T>) : Iterable<T> {
     private val iterator = wrapped.iterator()
     override fun iterator() = iterator
 }

--- a/nodecore-spv/src/test/java/org/veriblock/spv/service/BlockStoreTest.kt
+++ b/nodecore-spv/src/test/java/org/veriblock/spv/service/BlockStoreTest.kt
@@ -1,6 +1,7 @@
 package org.veriblock.spv.service
 
 import io.kotest.matchers.shouldBe
+import io.ktor.utils.io.*
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.*
 import org.veriblock.core.Context
@@ -14,7 +15,9 @@ import org.veriblock.core.crypto.VbkHash
 import org.veriblock.core.crypto.asVbkHash
 import org.veriblock.core.crypto.asVbkPreviousBlockHash
 import org.veriblock.core.crypto.asVbkPreviousKeystoneHash
+import org.veriblock.core.miner.vbkBlockGenerator
 import org.veriblock.core.params.defaultMainNetParameters
+import org.veriblock.core.params.defaultRegTestParameters
 import org.veriblock.sdk.blockchain.store.StoredVeriBlockBlock
 import org.veriblock.sdk.models.VeriBlockBlock
 import org.veriblock.spv.SpvConfig
@@ -24,109 +27,82 @@ import java.math.BigInteger
 import java.security.MessageDigest
 import kotlin.random.Random
 
-@Ignore
 class BlockStoreTest {
-    private lateinit var blockStore: BlockStore
-    private lateinit var baseDir: File
+    private val regtest = defaultRegTestParameters
 
     init {
-        Context.set(defaultMainNetParameters)
+        Context.create(regtest)
     }
 
-    @Before
-    fun beforeTest() {
-        baseDir = File("blockStoreTests").also {
-            it.mkdir()
-        }
-        blockStore = BlockStore(defaultMainNetParameters, baseDir)
-    }
+    private val baseDir: File = createTempDir()
+    private var blockStore = BlockStore(regtest, baseDir)
+
 
     @After
     fun after() {
         baseDir.deleteRecursively()
     }
 
-    // TODO(warchant): Commented these tests, because they break invariant in BlockStore (see comment in class definition)
-//    @Test
-//    fun `should store and restore the given list of blocks`() {
-//        // Given
-//        val storedVeriBlockBlocks = (1..100).map {
-//            StoredVeriBlockBlock(
-//                randomVeriBlockBlock(height = it),
-//                BigInteger.ONE,
-//                randomVbkHash()
-//            )
-//        }
-//        // When
-//        blockStore.writeBlocks(storedVeriBlockBlocks)
-//        // Then
-//        storedVeriBlockBlocks.forEach {
-//            blockStore.readBlock(it.hash) shouldBe it
-//        }
-//    }
-//
-//    @Test
-//    fun `should store and restore the given block`() {
-//        // Given
-//        val storedVeriBlockBlock = StoredVeriBlockBlock(
-//            randomVeriBlockBlock(),
-//            BigInteger.ONE,
-//            randomVbkHash()
-//        )
-//        // When
-//        blockStore.writeBlock(storedVeriBlockBlock)
-//        // Then
-//        blockStore.readBlock(storedVeriBlockBlock.hash) shouldBe storedVeriBlockBlock
-//    }
-//
-//    @Test
-//    fun `should properly update the block store tip`() {
-//        // Given
-//        val storedVeriBlockBlock = StoredVeriBlockBlock(
-//            randomVeriBlockBlock(),
-//            BigInteger.ONE,
-//            randomVbkHash()
-//        )
-//        // When
-//        blockStore.writeBlock(storedVeriBlockBlock)
-//        blockStore.setTip(storedVeriBlockBlock)
-//        // Then
-//        blockStore.getTip() shouldBe storedVeriBlockBlock
-//    }
-//
-//    @Test
-//    fun `shouldn't be able to restore a block with a wrong hash`() {
-//        // Given
-//        val storedVeriBlockBlock = StoredVeriBlockBlock(
-//            randomVeriBlockBlock(),
-//            BigInteger.ONE,
-//            randomVbkHash()
-//        )
-//        // When
-//        blockStore.writeBlock(storedVeriBlockBlock)
-//        // Then
-//        blockStore.readBlock(randomVbkHash()) shouldBe null
-//    }
-//
-//    @Test
-//    fun `should restore the blocks which were stored by a previous block store object`() {
-//        // Given
-//        val storedVeriBlockBlocks = (1..100).map {
-//            StoredVeriBlockBlock(
-//                randomVeriBlockBlock(height = it),
-//                BigInteger.ONE,
-//                randomVbkHash()
-//            )
-//        }
-//        // When
-//        blockStore.writeBlocks(storedVeriBlockBlocks)
-//        blockStore = BlockStore(defaultMainNetParameters, baseDir)
-//        // Then
-//        storedVeriBlockBlocks.forEach {
-//            blockStore.readBlock(it.hash) shouldBe it
-//        }
-//    }
-//}
+    @Test
+    fun `should store and restore the given list of blocks`() {
+        // Given
+        (1..100).map {
+            StoredVeriBlockBlock(
+                randomVeriBlockBlock(height = it),
+                BigInteger.ONE,
+                randomVbkHash()
+            )
+        }
+            // When
+            .map {
+                blockStore.appendBlock(it)
+            }
+        // Then
+        var count = 0
+        blockStore.forEach { _, _ ->
+            count++
+            true
+        }
+
+        count shouldBe 100
+    }
+
+    @Test
+    fun `should store and restore the given block`() {
+        // Given
+        val storedVeriBlockBlock = StoredVeriBlockBlock(
+            randomVeriBlockBlock(),
+            BigInteger.ONE,
+            randomVbkHash()
+        )
+        // When
+        blockStore.writeBlock(0, storedVeriBlockBlock)
+        // Then
+        blockStore.readBlock(0) shouldBe storedVeriBlockBlock
+    }
+
+    @Test
+    fun `should restore the blocks which were stored by a previous block store object`() {
+        // Given
+        val list = (1..100).map {
+            StoredVeriBlockBlock(
+                randomVeriBlockBlock(height = it),
+                BigInteger.ONE,
+                randomVbkHash()
+            )
+        }
+
+        val pos = list.map {
+            blockStore.appendBlock(it)
+        }
+        // When
+        blockStore = BlockStore(regtest, baseDir)
+        // Then
+        list.zip(pos).forEach { (block, position) ->
+            blockStore.readBlock(position) shouldBe block
+        }
+    }
+}
 
 private var messageDigest = MessageDigest.getInstance("SHA-256")
 private fun randomByteArray(size: Int): ByteArray = ByteArray(size) { randomInt(256).toByte() }

--- a/nodecore-spv/src/test/java/org/veriblock/spv/service/BlockStoreTest.kt
+++ b/nodecore-spv/src/test/java/org/veriblock/spv/service/BlockStoreTest.kt
@@ -24,6 +24,7 @@ import java.math.BigInteger
 import java.security.MessageDigest
 import kotlin.random.Random
 
+@Ignore
 class BlockStoreTest {
     private lateinit var blockStore: BlockStore
     private lateinit var baseDir: File
@@ -45,86 +46,87 @@ class BlockStoreTest {
         baseDir.deleteRecursively()
     }
 
-    @Test
-    fun `should store and restore the given list of blocks`() {
-        // Given
-        val storedVeriBlockBlocks = (1..100).map {
-            StoredVeriBlockBlock(
-                randomVeriBlockBlock(height = it),
-                BigInteger.ONE,
-                randomVbkHash()
-            )
-        }
-        // When
-        blockStore.writeBlocks(storedVeriBlockBlocks)
-        // Then
-        storedVeriBlockBlocks.forEach {
-            blockStore.readBlock(it.hash) shouldBe it
-        }
-    }
-
-    @Test
-    fun `should store and restore the given block`() {
-        // Given
-        val storedVeriBlockBlock = StoredVeriBlockBlock(
-            randomVeriBlockBlock(),
-            BigInteger.ONE,
-            randomVbkHash()
-        )
-        // When
-        blockStore.writeBlock(storedVeriBlockBlock)
-        // Then
-        blockStore.readBlock(storedVeriBlockBlock.hash) shouldBe storedVeriBlockBlock
-    }
-
-    @Test
-    fun `should properly update the block store tip`() {
-        // Given
-        val storedVeriBlockBlock = StoredVeriBlockBlock(
-            randomVeriBlockBlock(),
-            BigInteger.ONE,
-            randomVbkHash()
-        )
-        // When
-        blockStore.writeBlock(storedVeriBlockBlock)
-        blockStore.setTip(storedVeriBlockBlock)
-        // Then
-        blockStore.getTip() shouldBe storedVeriBlockBlock
-    }
-
-    @Test
-    fun `shouldn't be able to restore a block with a wrong hash`() {
-        // Given
-        val storedVeriBlockBlock = StoredVeriBlockBlock(
-            randomVeriBlockBlock(),
-            BigInteger.ONE,
-            randomVbkHash()
-        )
-        // When
-        blockStore.writeBlock(storedVeriBlockBlock)
-        // Then
-        blockStore.readBlock(randomVbkHash()) shouldBe null
-    }
-
-    @Test
-    fun `should restore the blocks which were stored by a previous block store object`() {
-        // Given
-        val storedVeriBlockBlocks = (1..100).map {
-            StoredVeriBlockBlock(
-                randomVeriBlockBlock(height = it),
-                BigInteger.ONE,
-                randomVbkHash()
-            )
-        }
-        // When
-        blockStore.writeBlocks(storedVeriBlockBlocks)
-        blockStore = BlockStore(defaultMainNetParameters, baseDir)
-        // Then
-        storedVeriBlockBlocks.forEach {
-            blockStore.readBlock(it.hash) shouldBe it
-        }
-    }
-}
+    // TODO(warchant): Commented these tests, because they break invariant in BlockStore (see comment in class definition)
+//    @Test
+//    fun `should store and restore the given list of blocks`() {
+//        // Given
+//        val storedVeriBlockBlocks = (1..100).map {
+//            StoredVeriBlockBlock(
+//                randomVeriBlockBlock(height = it),
+//                BigInteger.ONE,
+//                randomVbkHash()
+//            )
+//        }
+//        // When
+//        blockStore.writeBlocks(storedVeriBlockBlocks)
+//        // Then
+//        storedVeriBlockBlocks.forEach {
+//            blockStore.readBlock(it.hash) shouldBe it
+//        }
+//    }
+//
+//    @Test
+//    fun `should store and restore the given block`() {
+//        // Given
+//        val storedVeriBlockBlock = StoredVeriBlockBlock(
+//            randomVeriBlockBlock(),
+//            BigInteger.ONE,
+//            randomVbkHash()
+//        )
+//        // When
+//        blockStore.writeBlock(storedVeriBlockBlock)
+//        // Then
+//        blockStore.readBlock(storedVeriBlockBlock.hash) shouldBe storedVeriBlockBlock
+//    }
+//
+//    @Test
+//    fun `should properly update the block store tip`() {
+//        // Given
+//        val storedVeriBlockBlock = StoredVeriBlockBlock(
+//            randomVeriBlockBlock(),
+//            BigInteger.ONE,
+//            randomVbkHash()
+//        )
+//        // When
+//        blockStore.writeBlock(storedVeriBlockBlock)
+//        blockStore.setTip(storedVeriBlockBlock)
+//        // Then
+//        blockStore.getTip() shouldBe storedVeriBlockBlock
+//    }
+//
+//    @Test
+//    fun `shouldn't be able to restore a block with a wrong hash`() {
+//        // Given
+//        val storedVeriBlockBlock = StoredVeriBlockBlock(
+//            randomVeriBlockBlock(),
+//            BigInteger.ONE,
+//            randomVbkHash()
+//        )
+//        // When
+//        blockStore.writeBlock(storedVeriBlockBlock)
+//        // Then
+//        blockStore.readBlock(randomVbkHash()) shouldBe null
+//    }
+//
+//    @Test
+//    fun `should restore the blocks which were stored by a previous block store object`() {
+//        // Given
+//        val storedVeriBlockBlocks = (1..100).map {
+//            StoredVeriBlockBlock(
+//                randomVeriBlockBlock(height = it),
+//                BigInteger.ONE,
+//                randomVbkHash()
+//            )
+//        }
+//        // When
+//        blockStore.writeBlocks(storedVeriBlockBlocks)
+//        blockStore = BlockStore(defaultMainNetParameters, baseDir)
+//        // Then
+//        storedVeriBlockBlocks.forEach {
+//            blockStore.readBlock(it.hash) shouldBe it
+//        }
+//    }
+//}
 
 private var messageDigest = MessageDigest.getInstance("SHA-256")
 private fun randomByteArray(size: Int): ByteArray = ByteArray(size) { randomInt(256).toByte() }

--- a/nodecore-spv/src/test/kotlin/org/veriblock/spv/blockchain/BlockchainTest.kt
+++ b/nodecore-spv/src/test/kotlin/org/veriblock/spv/blockchain/BlockchainTest.kt
@@ -42,7 +42,9 @@ class BlockchainTest {
     @Test
     fun `mine single chain`() {
         var lastBlock: VeriBlockBlock? = null
-        generateBlock(blockchain.getChainHeadBlock().header).take(2100).forEach {
+        val lastBlock = generateBlock(blockchain.getChainHeadBlock().header).take(2100).onEach {
+          blockchain.acceptBlock(it) shouldBe true
+        }.last()
             lastBlock = it
             val isValid = blockchain.acceptBlock(it)
             Assert.assertTrue(isValid)

--- a/veriblock-core/src/main/java/org/veriblock/core/crypto/VbkHash.kt
+++ b/veriblock-core/src/main/java/org/veriblock/core/crypto/VbkHash.kt
@@ -42,7 +42,7 @@ private fun AnyVbkHash.trimBytes(size: Int): ByteArray {
     }
 }
 
-class VbkHash(bytes: ByteArray) : AnyVbkHash(bytes) {
+class VbkHash(bytes: ByteArray = ByteArray(VBK_HASH_LENGTH)) : AnyVbkHash(bytes) {
     init {
         check(bytes.size == VBK_HASH_LENGTH) {
             "Trying to create a VBK hash with invalid amount of bytes: ${bytes.size} (${bytes.toHex()})"
@@ -56,7 +56,7 @@ class VbkHash(bytes: ByteArray) : AnyVbkHash(bytes) {
         PreviousKeystoneVbkHash(trimBytes(VBK_PREVIOUS_KEYSTONE_HASH_LENGTH))
 }
 
-class PreviousBlockVbkHash(bytes: ByteArray) : AnyVbkHash(bytes) {
+class PreviousBlockVbkHash(bytes: ByteArray = ByteArray(VBK_PREVIOUS_BLOCK_HASH_LENGTH)) : AnyVbkHash(bytes) {
     init {
         check(bytes.size == VBK_PREVIOUS_BLOCK_HASH_LENGTH) {
             "Trying to create a previous block VBK hash with invalid amount of bytes: ${bytes.size} (${bytes.toHex()})"
@@ -96,10 +96,12 @@ fun ByteBuffer.readVbkHash(): VbkHash = ByteArray(VBK_HASH_LENGTH).let {
     get(it)
     VbkHash(it)
 }
+
 fun ByteBuffer.readVbkPreviousBlockHash(): PreviousBlockVbkHash = ByteArray(VBK_PREVIOUS_BLOCK_HASH_LENGTH).let {
     get(it)
     PreviousBlockVbkHash(it)
 }
+
 fun ByteBuffer.readVbkPreviousKeystoneHash(): PreviousKeystoneVbkHash = ByteArray(VBK_PREVIOUS_KEYSTONE_HASH_LENGTH).let {
     get(it)
     PreviousKeystoneVbkHash(it)
@@ -138,15 +140,19 @@ class EgPreviousKeystoneVbkHash(bytes: ByteArray) : PreviousKeystoneVbkHash(byte
 object VbkHashUtil {
     @JvmStatic
     fun wrap(bytes: ByteArray): VbkHash = VbkHash(bytes)
+
     @JvmStatic
     fun wrapPreviousBlockHash(bytes: ByteArray): PreviousBlockVbkHash = PreviousBlockVbkHash(bytes)
+
     @JvmStatic
     fun wrapPreviousKeystoneHash(bytes: ByteArray): PreviousKeystoneVbkHash = PreviousKeystoneVbkHash(bytes)
 
     @JvmStatic
     fun wrap(hex: String): VbkHash = wrap(hex.asHexBytes())
+
     @JvmStatic
     fun wrapPreviousBlockHash(hex: String): PreviousBlockVbkHash = wrapPreviousBlockHash(hex.asHexBytes())
+
     @JvmStatic
     fun wrapPreviousKeystoneHash(hex: String): PreviousKeystoneVbkHash = wrapPreviousKeystoneHash(hex.asHexBytes())
 }


### PR DESCRIPTION
Changes:
- [x] Add Chain - now we keep track of active chain blocks, so we can respond in O(1) on queries "GetBlockByHeight"
- [x] Refactor Block Storage - now it stores only blocks (does not store index on-disk). Instead of reading index, we read all Blocks from disk, re-generating index on-the-fly.

Commented BlockStore tests, because they break assumption that blocks are connected.