### PR TITLE
Changed behavior to allow apm to only connect to nodecore instances s…

### DIFF
--- a/nodecore-p2p/src/main/kotlin/nodecore/p2p/P2pConfiguration.kt
+++ b/nodecore-p2p/src/main/kotlin/nodecore/p2p/P2pConfiguration.kt
@@ -16,6 +16,7 @@ class P2pConfiguration(
     val bootstrapPeers: List<String> = emptyList(),
     val bootstrappingDnsSeeds: List<String> = emptyList(),
     val externalPeerEndpoints: List<NetworkAddress> = emptyList(),
+    val useAdditionalPeers: Boolean = true,
     val peerSharePlatform: Boolean = false,
     val peerPublishAddress: String = "",
     val peerShareMyAddress: Boolean = false,

--- a/nodecore-spv/nodecore-spv-standalone/src/main/kotlin/org/veriblock/spv/standalone/VeriBlockSPV.kt
+++ b/nodecore-spv/nodecore-spv-standalone/src/main/kotlin/org/veriblock/spv/standalone/VeriBlockSPV.kt
@@ -47,6 +47,7 @@ private val spvConfig: SpvConfig = SpvConfig(
     connectDirectlyTo = config.getOrNull("connectDirectlyTo") {
         getStringList(it)
     }?: emptyList(),
+    useAdditionalPeers = config.getBoolean("useAdditionalPeers") ?: true,
     trustPeerHashes = config.getBoolean("trustPeerHashes") ?: false
 )
 

--- a/nodecore-spv/src/main/java/org/veriblock/spv/SpvContext.kt
+++ b/nodecore-spv/src/main/java/org/veriblock/spv/SpvContext.kt
@@ -69,10 +69,19 @@ class SpvContext(
 
     private val addressState: ConcurrentHashMap<Address, LedgerContext> = ConcurrentHashMap()
 
+    val useAdditionalPeers = config.useAdditionalPeers
     val trustPeerHashes = config.trustPeerHashes
     val startTime: Instant = Instant.now()
 
     init {
+        if (!useAdditionalPeers) {
+            logger.warn {
+                "Additional peer use is disabled." +
+                    " With this feature SPV connects only to the endpoints specified in the configuration file." +
+                    " In order to control the connections, locate 'connectDirectlyTo' in the configuration file and modify the list."
+            }
+        }
+
         if (trustPeerHashes) {
             logger.warn {
                 "Fast sync mode is enabled." +
@@ -123,6 +132,7 @@ class SpvContext(
                 peerBootstrapEnabled = bootstrappingDnsSeeds.isNotEmpty() && externalPeerEndpoints.isEmpty(),
                 bootstrappingDnsSeeds = bootstrappingDnsSeeds,
                 externalPeerEndpoints = externalPeerEndpoints,
+                useAdditionalPeers = useAdditionalPeers,
                 capabilities = PeerCapabilities.spvCapabilities(),
                 neededCapabilities = PeerCapabilities.defaultCapabilities() and config.extraNeededCapabilities,
                 fullProgramNameVersion = SpvConstants.FULL_PROGRAM_NAME_VERSION
@@ -215,6 +225,7 @@ class SpvConfig(
     val networkParameters: NetworkParameters = defaultMainNetParameters,
     val dataDir: String = ".",
     val connectDirectlyTo: List<String> = emptyList(),
+    val useAdditionalPeers: Boolean = true,
     val trustPeerHashes: Boolean = false,
     val extraNeededCapabilities: Set<PeerCapabilities.Capability> = emptySet()
 )

--- a/pop-miners/altchain-pop-miner/src/main/kotlin/org/veriblock/miners/pop/service/AltchainPopMinerService.kt
+++ b/pop-miners/altchain-pop-miner/src/main/kotlin/org/veriblock/miners/pop/service/AltchainPopMinerService.kt
@@ -405,8 +405,7 @@ class AltchainPopMinerService(
                 networkParameters,
                 dataDir = context.dataDir,
                 connectDirectlyTo = config.connectDirectlyTo,
-                trustPeerHashes = true,
-                extraNeededCapabilities = setOf(PeerCapabilities.Capability.VtbRequests)
+                useAdditionalPeers = false
             )
         )
         spvContext.start()


### PR DESCRIPTION
…pecified in config file.

Multiple instances are still allowed. This removes the peer discovery and makes the reconnect able to connect back to the original specified instances.