### PR TITLE
Project update to work on apple M1 CPU

### DIFF
--- a/nodecore-grpc/build.gradle.kts
+++ b/nodecore-grpc/build.gradle.kts
@@ -25,9 +25,9 @@ plugins {
 dependencies {
     compile(project(":veriblock-core"))
 
-    compile("io.grpc:grpc-netty-shaded:1.25.0")
-    compile("io.grpc:grpc-protobuf:1.25.0")
-    compile("io.grpc:grpc-stub:1.25.0")
+    compile("io.grpc:grpc-netty-shaded:1.42.1")
+    compile("io.grpc:grpc-protobuf:1.42.1")
+    compile("io.grpc:grpc-stub:1.42.1")
 
     compileOnly("javax.annotation:javax.annotation-api:1.2")
 }
@@ -36,12 +36,12 @@ protobuf {
     generatedFilesBaseDir = "$projectDir/src/generated"
 
     protoc {
-        artifact = "com.google.protobuf:protoc:3.6.1"
+        artifact = "com.google.protobuf:protoc:3.17.3"
     }
 
     plugins {
         id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.19.0"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.42.1"
         }
     }
 

--- a/pop-miners/altchain-pop-miner/build.gradle.kts
+++ b/pop-miners/altchain-pop-miner/build.gradle.kts
@@ -179,8 +179,8 @@ setupJacoco()
 val spaClientDir = "$projectDir/src/main/spa-client"
 
 node {
-    version = "14.15.1"
-    npmVersion = "6.14.0"
+    version = "15.14.0"
+    npmVersion = "7.7.6"
 
     download = true
 


### PR DESCRIPTION
This change is needed for the project to build with gradle on new Apple M1 machines. Without it the project nodecore-grpc fails to build and the altchain-pop-miner has some strange behavior at the angular app